### PR TITLE
Fix divide by zero error

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/N5ConvertSpark.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/N5ConvertSpark.java
@@ -312,7 +312,7 @@ public class N5ConvertSpark
 		// adjust the size of the processing block to minimize number of reads of each input block
 		final int[] adjustedBlockSize = new int[ inputBlockSize.length ];
 		for ( int d = 0; d < adjustedBlockSize.length; ++d )
-			adjustedBlockSize[ d ] = ( int ) Math.round( ( double ) inputBlockSize[ d ] / outputBlockSize[ d ] ) * outputBlockSize[ d ];
+			adjustedBlockSize[ d ] = ( int ) Math.max( Math.round( ( double ) inputBlockSize[ d ] / outputBlockSize[ d ] ), 1) * outputBlockSize[ d ];
 
 		final long numAdjustedBlocks = Intervals.numElements( new CellGrid( dimensions, adjustedBlockSize ).getGridDimensions() );
 		final List< Long > adjustedBlockIndexes = LongStream.range( 0, numAdjustedBlocks ).boxed().collect( Collectors.toList() );


### PR DESCRIPTION
When converting an N5 dataset to a block size where one of the dimensions was more than double the previous block size, Math.round caused the adjusted block size to become 0, yielding a divide-by-zero `ArithmeticException`.

This fixes that behavior by putting a lower bound of the output block size on the adjusted block size, preventing it from going to 0.