### PR TITLE
Add ability to specify multiple (different) downsampling factors

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/downsample/N5DownsamplerSpark.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/downsample/N5DownsamplerSpark.java
@@ -18,6 +18,7 @@ import org.janelia.saalfeldlab.n5.spark.util.CmdUtils;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
+import org.kohsuke.args4j.spi.StringArrayOptionHandler;
 
 import bdv.export.Downsample;
 import net.imglib2.FinalInterval;
@@ -168,14 +169,32 @@ public class N5DownsamplerSpark
 			) )
 		{
 			final N5WriterSupplier n5Supplier = () -> new N5FSWriter( parsedArgs.getN5Path() );
+			
+			final String[] outputDatasetPath = parsedArgs.getOutputDatasetPath();
+			final int[][] downsamplingFactors = parsedArgs.getDownsamplingFactors();
+			
+			if ( outputDatasetPath.length != downsamplingFactors.length )
+				throw new IllegalArgumentException( "Number of output datasets does not match downsampling factors!" );
+			
 			downsample(
 					sparkContext,
 					n5Supplier,
 					parsedArgs.getInputDatasetPath(),
-					parsedArgs.getOutputDatasetPath(),
-					parsedArgs.getDownsamplingFactors(),
+					outputDatasetPath[0],
+					downsamplingFactors[0],
 					parsedArgs.getBlockSize()
 				);
+			
+			for ( int i = 1; i < downsamplingFactors.length; i++ )
+			{
+				downsample(
+						sparkContext,
+						n5Supplier,
+						outputDatasetPath[ i - 1 ],
+						outputDatasetPath[ i ],
+						downsamplingFactors[ i ],
+						parsedArgs.getBlockSize() );
+			}
 		}
 		System.out.println( "Done" );
 	}
@@ -192,13 +211,13 @@ public class N5DownsamplerSpark
 				usage = "Path to the input dataset within the N5 container (e.g. data/group/s0).")
 		private String inputDatasetPath;
 
-		@Option(name = "-o", aliases = { "--outputDatasetPath" }, required = true,
-				usage = "Path to the output dataset to be created (e.g. data/group/s1).")
-		private String outputDatasetPath;
+		@Option(name = "-o", aliases = { "--outputDatasetPath" }, required = true, handler = StringArrayOptionHandler.class,
+				usage = "Path(s) to the output dataset to be created (e.g. data/group/s1).")
+		private String[] outputDatasetPath;
 
-		@Option(name = "-f", aliases = { "--factors" }, required = true,
-				usage = "Downsampling factors.")
-		private String downsamplingFactors;
+		@Option(name = "-f", aliases = { "--factors" }, required = true, handler = StringArrayOptionHandler.class,
+				usage = "Downsampling factors. If using multiple, each factor builds on the last.")
+		private String[] downsamplingFactors;
 
 		@Option(name = "-b", aliases = { "--blockSize" }, required = false,
 				usage = "Block size for the output dataset (by default same as for input dataset).")
@@ -221,8 +240,8 @@ public class N5DownsamplerSpark
 
 		public String getN5Path() { return n5Path; }
 		public String getInputDatasetPath() { return inputDatasetPath; }
-		public String getOutputDatasetPath() { return outputDatasetPath; }
-		public int[] getDownsamplingFactors() { return CmdUtils.parseIntArray( downsamplingFactors ); }
+		public String[] getOutputDatasetPath() { return outputDatasetPath; }
+		public int[][] getDownsamplingFactors() { return CmdUtils.parseMultipleIntArrays( downsamplingFactors ); }
 		public int[] getBlockSize() { return CmdUtils.parseIntArray( blockSize ); }
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/util/CmdUtils.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/util/CmdUtils.java
@@ -26,6 +26,25 @@ public class CmdUtils
 		return values;
 	}
 
+	public static int[][] parseMultipleIntArrays( final String[] strs )
+	{
+		if ( strs == null )
+			return null;
+
+		final String[][] tokens = new String[strs.length][];
+		for ( int i = 0; i < strs.length; i++ )
+			tokens[i] = strs[i].split( "," );
+
+		final int[][] values = new int[ tokens.length ][];
+		for ( int i = 0; i < values.length; i++ )
+		{
+			values[ i ] = new int[ tokens[ i ].length ];
+			for ( int j = 0; j < values[ i ].length; j++ )
+				values[ i ][ j ] = Integer.parseInt( tokens[ i ][ j ] );
+		}
+		return values;
+	}
+
 	public static long[] parseLongArray( final String str )
 	{
 		if ( str == null )


### PR DESCRIPTION
This adds the ability to specify multiple different downsampling factors with raw data (`N5Downsampler.java`), for ease of use in creating scale pyramids for anisotropic data in scenarios where specific factors are required. To use different downsampling factors, simply specify multiple output datasets and multiple factors like so:
```
... --outputDatasetPath downscaled/s1 downscaled/s2 downscaled/s3 --factors 2,2,1 2,2,2 2,2,1 ...
```
The factors each build upon the previous one, and downscale in the order specified (the first factor is applied first, and written to the first output dataset, etc.)

If desired, I can implement this functionality in a similar way for `N5LabelDownsamplerSpark` as well.

cc @axtimwalde @igorpisarev 