### PR TITLE
Turn off slow TIFF compression by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,8 +297,8 @@ spark-janelia/n5-slice-tiff.py
 -n <path to n5 root> 
 -i <input dataset> 
 -o <output path> 
-[-c <tiff compression>]
 [-d <slice dimension>]
+[-c <tiff compression>]
 ```
 </details>
 
@@ -310,14 +310,16 @@ spark-local/n5-slice-tiff.py
 -n <path to n5 root> 
 -i <input dataset> 
 -o <output path> 
-[-c <tiff compression>]
 [-d <slice dimension>]
+[-c <tiff compression>]
 ```
 </details>
 
 The tool converts a given dataset into slice TIFF series and saves them in the specified output folder.<br/>
-The following TIFF compression modes are supported: `-c lzw` (default) and `-c none`.<br/>
 The slice dimension can be specified as `-d x`, `-d y`, or `-d z` (default) to generate YZ, XZ, or XY slices respectively.
+
+Output TIFF images are written as uncompressed by default. LZW compression can be enabled by supplying `-c lzw`.<br/>
+**WARNING:** LZW compressor can be very slow. It is not recommended for general use unless saving disk space is crucial.
 
 
 ### N5 max intensity projection
@@ -331,8 +333,8 @@ spark-janelia/n5-mips.py
 -n <path to n5 root> 
 -i <input dataset> 
 -o <output path> 
-[-c <tiff compression>]
 [-m <mip step>]
+[-c <tiff compression>]
 ```
 </details>
 
@@ -344,14 +346,16 @@ spark-local/n5-mips.py
 -n <path to n5 root> 
 -i <input dataset> 
 -o <output path> 
-[-c <tiff compression>]
 [-m <mip step>]
+[-c <tiff compression>]
 ```
 </details>
 
 The tool generates max intensity projections in X/Y/Z directions and saves them as TIFF images in the specified output folder.<br/>
 By default the entire volume is used to create a single MIP in X/Y/Z. You can specify MIP step as a number of cells included in a single MIP (e.g. `-m 5,5,3`).<br/>
-The following TIFF compression modes are supported: `-c lzw` and `-c none`.
+
+Output TIFF images are written as uncompressed by default. LZW compression can be enabled by supplying `-c lzw`.<br/>
+**WARNING:** LZW compressor can be very slow. It is not recommended for general use unless saving disk space is crucial.
 
 
 ### N5 remove

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/N5MaxIntensityProjection.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/N5MaxIntensityProjection.java
@@ -335,8 +335,9 @@ public class N5MaxIntensityProjection
 		private String outputPath;
 
 		@Option(name = "-c", aliases = { "--tiffCompression" }, required = false,
-				usage = "Tiff compression (LZW or NONE).")
-		private TiffCompression tiffCompression = TiffCompression.LZW;
+				usage = "Tiff compression (not used by default)."
+						+ "WARNING: LZW compressor can be very slow. It is not recommended for general use unless saving disk space is crucial.")
+		private TiffCompression tiffCompression = TiffCompression.NONE;
 
 		@Option(name = "-m", aliases = { "--mipCellsStep" }, required = false,
 				usage = "Number of cells used for a single MIP image (MIP step in X/Y/Z). By default the MIP is computed through the entire volume.")

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/N5SliceTiffConverter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/N5SliceTiffConverter.java
@@ -178,8 +178,9 @@ public class N5SliceTiffConverter
 		private String outputPath;
 
 		@Option(name = "-c", aliases = { "--tiffCompression" }, required = false,
-				usage = "Tiff compression")
-		private TiffCompression tiffCompression = TiffCompression.LZW;
+				usage = "Tiff compression (not used by default)."
+						+ "WARNING: LZW compressor can be very slow. It is not recommended for general use unless saving disk space is crucial.")
+		private TiffCompression tiffCompression = TiffCompression.NONE;
 
 		@Option(name = "-d", aliases = { "--sliceDimension" }, required = false,
 				usage = "Dimension to slice over as a string")


### PR DESCRIPTION
It's been reported that writing TIFF images compressed with LZW is very slow, in particular on network file systems. For this reason, use of LZW compression is now discouraged, and the default behavior is now to write uncompressed data.

The currently integrated LZW compression is based on `bio-formats_plugins`. Need to find and benchmark other TIFF compression implementations (will have to make sure that resulting images are compatible with Fiji and other common image processing applications).