### PR TITLE
Remove conda installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,6 @@ If you have already cloned the repository, run this after cloning to fetch the s
 git submodule update --init --recursive
 ```
 
-`n5-spark` for use on local machine is available on conda:
-```
-conda -c hanslovsky install n5-spark
-```
-
 Alternatively, to use as a standalone tool, compile the package for the desired execution environment:
 
 <details>


### PR DESCRIPTION
Conda installation instructions are incorrect and version on conda is outdated and does not work. I will probably remove the package from my channel sometime in the not too distant future.