### PR TITLE
Improve tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5</artifactId>
-			<version>2.1.3</version>
+			<version>2.1.6</version>
 		</dependency>
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>

--- a/src/test/java/org/janelia/saalfeldlab/n5/spark/AbstractN5SparkTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/spark/AbstractN5SparkTest.java
@@ -1,0 +1,42 @@
+package org.janelia.saalfeldlab.n5.spark;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.janelia.saalfeldlab.n5.N5FSWriter;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public abstract class AbstractN5SparkTest implements Serializable
+{
+    protected String basePath;
+    protected transient JavaSparkContext sparkContext;
+
+    @Before
+    public void setUp()
+    {
+        sparkContext = new JavaSparkContext( new SparkConf()
+                .setMaster( "local[*]" )
+                .setAppName( getClass().getName() )
+                .set( "spark.serializer", "org.apache.spark.serializer.KryoSerializer" )
+        );
+
+        basePath = System.getProperty( "user.home" ) + "/.n5-spark-test-" + RandomStringUtils.randomAlphanumeric( 5 );
+    }
+
+    @After
+    public void tearDown() throws IOException
+    {
+        if ( sparkContext != null )
+            sparkContext.close();
+
+        if ( Files.exists( Paths.get( basePath ) ) )
+            Assert.assertTrue( new N5FSWriter( basePath ).remove() );
+    }
+}

--- a/src/test/java/org/janelia/saalfeldlab/n5/spark/downsample/N5LabelDownsamplerSparkTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/spark/downsample/N5LabelDownsamplerSparkTest.java
@@ -1,67 +1,31 @@
 package org.janelia.saalfeldlab.n5.spark.downsample;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.spark.SparkConf;
-import org.apache.spark.api.java.JavaSparkContext;
-import org.janelia.saalfeldlab.n5.DatasetAttributes;
-import org.janelia.saalfeldlab.n5.GzipCompression;
-import org.janelia.saalfeldlab.n5.N5FSWriter;
-import org.janelia.saalfeldlab.n5.N5Writer;
-import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
-import org.janelia.saalfeldlab.n5.spark.supplier.N5WriterSupplier;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.type.numeric.integer.UnsignedLongType;
 import net.imglib2.util.Intervals;
 import net.imglib2.view.Views;
+import org.janelia.saalfeldlab.n5.DatasetAttributes;
+import org.janelia.saalfeldlab.n5.GzipCompression;
+import org.janelia.saalfeldlab.n5.N5FSWriter;
+import org.janelia.saalfeldlab.n5.N5Writer;
+import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
+import org.janelia.saalfeldlab.n5.spark.AbstractN5SparkTest;
+import org.junit.Assert;
+import org.junit.Test;
 
-public class N5LabelDownsamplerSparkTest
+import java.io.IOException;
+
+public class N5LabelDownsamplerSparkTest extends AbstractN5SparkTest
 {
-	static private final String basePath = System.getProperty("user.home") + "/.n5-spark-test-" + RandomStringUtils.randomAlphanumeric(5);
 	static private final String datasetPath = "data";
 	static private final String downsampledDatasetPath = "downsampled-data";
-
-	static private final N5WriterSupplier n5Supplier = () -> new N5FSWriter( basePath );
-
-	private JavaSparkContext sparkContext;
-
-	@Before
-	public void setUp() throws IOException
-	{
-		// cleanup in case the test has failed
-		tearDown();
-
-		sparkContext = new JavaSparkContext( new SparkConf()
-				.setMaster( "local[*]" )
-				.setAppName( "N5LabelDownsamplerTest" )
-				.set( "spark.serializer", "org.apache.spark.serializer.KryoSerializer" )
-			);
-	}
-
-	@After
-	public void tearDown() throws IOException
-	{
-		if ( sparkContext != null )
-			sparkContext.close();
-
-		if ( Files.exists( Paths.get( basePath ) ) )
-			n5Supplier.get().remove();
-	}
 
 	@Test
 	public void testLabelDownsampling() throws IOException
 	{
-		final N5Writer n5 = n5Supplier.get();
+		final N5Writer n5 = new N5FSWriter( basePath );
 
 		N5Utils.save(
 				ArrayImgs.unsignedLongs(
@@ -86,7 +50,7 @@ public class N5LabelDownsamplerSparkTest
 
 		N5LabelDownsamplerSpark.downsampleLabel(
 				sparkContext,
-				n5Supplier,
+				() -> new N5FSWriter( basePath ),
 				datasetPath,
 				downsampledDatasetPath,
 				new int[] { 2, 2, 2 }

--- a/src/test/java/org/janelia/saalfeldlab/n5/spark/downsample/N5OffsetDownsamplerSparkTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/spark/downsample/N5OffsetDownsamplerSparkTest.java
@@ -1,23 +1,5 @@
 package org.janelia.saalfeldlab.n5.spark.downsample;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.spark.SparkConf;
-import org.apache.spark.api.java.JavaSparkContext;
-import org.janelia.saalfeldlab.n5.DatasetAttributes;
-import org.janelia.saalfeldlab.n5.GzipCompression;
-import org.janelia.saalfeldlab.n5.N5FSWriter;
-import org.janelia.saalfeldlab.n5.N5Writer;
-import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
-import org.janelia.saalfeldlab.n5.spark.supplier.N5WriterSupplier;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.array.ArrayImgs;
@@ -25,51 +7,33 @@ import net.imglib2.type.numeric.integer.IntType;
 import net.imglib2.util.Intervals;
 import net.imglib2.util.Util;
 import net.imglib2.view.Views;
+import org.janelia.saalfeldlab.n5.DatasetAttributes;
+import org.janelia.saalfeldlab.n5.GzipCompression;
+import org.janelia.saalfeldlab.n5.N5FSWriter;
+import org.janelia.saalfeldlab.n5.N5Writer;
+import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
+import org.janelia.saalfeldlab.n5.spark.AbstractN5SparkTest;
+import org.junit.Assert;
+import org.junit.Test;
 
-public class N5OffsetDownsamplerSparkTest
+import java.io.IOException;
+
+public class N5OffsetDownsamplerSparkTest extends AbstractN5SparkTest
 {
-	static private final String basePath = System.getProperty("user.home") + "/.n5-spark-test-" + RandomStringUtils.randomAlphanumeric(5);
 	static private final String datasetPath = "data";
 	static private final String downsampledDatasetPath = "downsampled-data";
-
-	static private final N5WriterSupplier n5Supplier = () -> new N5FSWriter( basePath );
-
-	private JavaSparkContext sparkContext;
-
-	@Before
-	public void setUp() throws IOException
-	{
-		// cleanup in case the test has failed
-		tearDown();
-
-		sparkContext = new JavaSparkContext( new SparkConf()
-				.setMaster( "local[*]" )
-				.setAppName( "N5OffsetDownsamplerTest" )
-				.set( "spark.serializer", "org.apache.spark.serializer.KryoSerializer" )
-			);
-	}
-
-	@After
-	public void tearDown() throws IOException
-	{
-		if ( sparkContext != null )
-			sparkContext.close();
-
-		if ( Files.exists( Paths.get( basePath ) ) )
-			n5Supplier.get().remove();
-	}
 
 	@Test
 	public void testDownsamplingWithPositiveOffset1D() throws IOException
 	{
-		final N5Writer n5 = n5Supplier.get();
+		final N5Writer n5 = new N5FSWriter( basePath );
 		for ( int blockSize = 1; blockSize <= 10; ++blockSize )
 		{
 			createDataset( n5, new long[] { 9 }, new int[] { blockSize } );
 
 			N5OffsetDownsamplerSpark.downsampleWithOffset(
 					sparkContext,
-					n5Supplier,
+					() -> new N5FSWriter( basePath ),
 					datasetPath,
 					downsampledDatasetPath,
 					new int[] { 4 },
@@ -89,21 +53,21 @@ public class N5OffsetDownsamplerSparkTest
 					getArrayFromRandomAccessibleInterval( N5Utils.open( n5, downsampledDatasetPath ) )
 				);
 
-			Assert.assertTrue( n5Supplier.get().remove( downsampledDatasetPath ) );
+			Assert.assertTrue( n5.remove( downsampledDatasetPath ) );
 		}
 	}
 
 	@Test
 	public void testDownsamplingWithNegativeOffset1D() throws IOException
 	{
-		final N5Writer n5 = n5Supplier.get();
+		final N5Writer n5 = new N5FSWriter( basePath );
 		for ( int blockSize = 1; blockSize <= 10; ++blockSize )
 		{
 			createDataset( n5, new long[] { 10 }, new int[] { blockSize } );
 
 			N5OffsetDownsamplerSpark.downsampleWithOffset(
 					sparkContext,
-					n5Supplier,
+					() -> new N5FSWriter( basePath ),
 					datasetPath,
 					downsampledDatasetPath,
 					new int[] { 3 },
@@ -123,14 +87,14 @@ public class N5OffsetDownsamplerSparkTest
 					getArrayFromRandomAccessibleInterval( N5Utils.open( n5, downsampledDatasetPath ) )
 				);
 
-			Assert.assertTrue( n5Supplier.get().remove( downsampledDatasetPath ) );
+			Assert.assertTrue( n5.remove( downsampledDatasetPath ) );
 		}
 	}
 
 	@Test
 	public void testDownsamplingWithOffset2D() throws IOException
 	{
-		final N5Writer n5 = n5Supplier.get();
+		final N5Writer n5 = new N5FSWriter( basePath );
 		for ( int blockSizeX = 1; blockSizeX <= 6; ++blockSizeX )
 		{
 			for ( int blockSizeY = 1; blockSizeY <= 8; ++blockSizeY )
@@ -139,7 +103,7 @@ public class N5OffsetDownsamplerSparkTest
 
 				N5OffsetDownsamplerSpark.downsampleWithOffset(
 						sparkContext,
-						n5Supplier,
+						() -> new N5FSWriter( basePath ),
 						datasetPath,
 						downsampledDatasetPath,
 						new int[] { 3, 3 },
@@ -158,7 +122,7 @@ public class N5OffsetDownsamplerSparkTest
 						getArrayFromRandomAccessibleInterval( N5Utils.open( n5, downsampledDatasetPath ) )
 					);
 
-				Assert.assertTrue( n5Supplier.get().remove( downsampledDatasetPath ) );
+				Assert.assertTrue( n5.remove( downsampledDatasetPath ) );
 			}
 		}
 	}

--- a/src/test/java/org/janelia/saalfeldlab/n5/spark/downsample/scalepyramid/N5OffsetScalePyramidSparkTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/spark/downsample/scalepyramid/N5OffsetScalePyramidSparkTest.java
@@ -1,25 +1,5 @@
 package org.janelia.saalfeldlab.n5.spark.downsample.scalepyramid;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.List;
-
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.spark.SparkConf;
-import org.apache.spark.api.java.JavaSparkContext;
-import org.janelia.saalfeldlab.n5.DatasetAttributes;
-import org.janelia.saalfeldlab.n5.GzipCompression;
-import org.janelia.saalfeldlab.n5.N5FSWriter;
-import org.janelia.saalfeldlab.n5.N5Writer;
-import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
-import org.janelia.saalfeldlab.n5.spark.supplier.N5WriterSupplier;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.array.ArrayImgs;
@@ -27,48 +7,33 @@ import net.imglib2.type.numeric.integer.IntType;
 import net.imglib2.util.Intervals;
 import net.imglib2.util.Util;
 import net.imglib2.view.Views;
+import org.janelia.saalfeldlab.n5.DatasetAttributes;
+import org.janelia.saalfeldlab.n5.GzipCompression;
+import org.janelia.saalfeldlab.n5.N5FSWriter;
+import org.janelia.saalfeldlab.n5.N5Writer;
+import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
+import org.janelia.saalfeldlab.n5.spark.AbstractN5SparkTest;
+import org.junit.Assert;
+import org.junit.Test;
 
-public class N5OffsetScalePyramidSparkTest
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.List;
+
+public class N5OffsetScalePyramidSparkTest extends AbstractN5SparkTest
 {
-	static private final String basePath = System.getProperty("user.home") + "/.n5-spark-test-" + RandomStringUtils.randomAlphanumeric(5);
 	static private final String datasetPath = "data";
-
-	static private final N5WriterSupplier n5Supplier = () -> new N5FSWriter( basePath );
-
-	private JavaSparkContext sparkContext;
-
-	@Before
-	public void setUp() throws IOException
-	{
-		// cleanup in case the test has failed
-		tearDown();
-
-		sparkContext = new JavaSparkContext( new SparkConf()
-				.setMaster( "local[*]" )
-				.setAppName( "N5OffsetScalePyramidTest" )
-				.set( "spark.serializer", "org.apache.spark.serializer.KryoSerializer" )
-			);
-	}
-
-	@After
-	public void tearDown() throws IOException
-	{
-		if ( sparkContext != null )
-			sparkContext.close();
-
-		if ( Files.exists( Paths.get( basePath ) ) )
-			n5Supplier.get().remove();
-	}
 
 	@Test
 	public void testDownsampling() throws IOException
 	{
-		final N5Writer n5 = n5Supplier.get();
+		final N5Writer n5 = new N5FSWriter( basePath );
 		createDataset( n5, new long[] { 4, 4, 4 }, new int[] { 1, 1, 1 } );
 
 		final List< String > scalePyramidDatasets = N5OffsetScalePyramidSpark.downsampleOffsetScalePyramid(
 				sparkContext,
-				n5Supplier,
+				() -> new N5FSWriter( basePath ),
 				datasetPath,
 				new int[] { 2, 2, 2 },
 				new boolean[] { true, true, true }

--- a/src/test/java/org/janelia/saalfeldlab/n5/spark/downsample/scalepyramid/N5ScalePyramidSparkTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/spark/downsample/scalepyramid/N5ScalePyramidSparkTest.java
@@ -1,25 +1,5 @@
 package org.janelia.saalfeldlab.n5.spark.downsample.scalepyramid;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.List;
-
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.spark.SparkConf;
-import org.apache.spark.api.java.JavaSparkContext;
-import org.janelia.saalfeldlab.n5.DatasetAttributes;
-import org.janelia.saalfeldlab.n5.GzipCompression;
-import org.janelia.saalfeldlab.n5.N5FSWriter;
-import org.janelia.saalfeldlab.n5.N5Writer;
-import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
-import org.janelia.saalfeldlab.n5.spark.supplier.N5WriterSupplier;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.array.ArrayImgs;
@@ -27,48 +7,33 @@ import net.imglib2.type.numeric.integer.IntType;
 import net.imglib2.util.Intervals;
 import net.imglib2.util.Util;
 import net.imglib2.view.Views;
+import org.janelia.saalfeldlab.n5.DatasetAttributes;
+import org.janelia.saalfeldlab.n5.GzipCompression;
+import org.janelia.saalfeldlab.n5.N5FSWriter;
+import org.janelia.saalfeldlab.n5.N5Writer;
+import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
+import org.janelia.saalfeldlab.n5.spark.AbstractN5SparkTest;
+import org.junit.Assert;
+import org.junit.Test;
 
-public class N5ScalePyramidSparkTest
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.List;
+
+public class N5ScalePyramidSparkTest extends AbstractN5SparkTest
 {
-	static private final String basePath = System.getProperty("user.home") + "/.n5-spark-test-" + RandomStringUtils.randomAlphanumeric(5);
 	static private final String datasetPath = "data";
-
-	static private final N5WriterSupplier n5Supplier = () -> new N5FSWriter( basePath );
-
-	private JavaSparkContext sparkContext;
-
-	@Before
-	public void setUp() throws IOException
-	{
-		// cleanup in case the test has failed
-		tearDown();
-
-		sparkContext = new JavaSparkContext( new SparkConf()
-				.setMaster( "local[*]" )
-				.setAppName( "N5ScalePyramidTest" )
-				.set( "spark.serializer", "org.apache.spark.serializer.KryoSerializer" )
-			);
-	}
-
-	@After
-	public void tearDown() throws IOException
-	{
-		if ( sparkContext != null )
-			sparkContext.close();
-
-		if ( Files.exists( Paths.get( basePath ) ) )
-			n5Supplier.get().remove();
-	}
 
 	@Test
 	public void testDownsampling() throws IOException
 	{
-		final N5Writer n5 = n5Supplier.get();
+		final N5Writer n5 = new N5FSWriter( basePath );
 		createDataset( n5, new long[] { 4, 4, 4 }, new int[] { 1, 1, 1 } );
 
 		final List< String > downsampledDatasets = N5ScalePyramidSpark.downsampleScalePyramid(
 				sparkContext,
-				n5Supplier,
+				() -> new N5FSWriter( basePath ),
 				datasetPath,
 				new int[] { 2, 2, 2 }
 			);


### PR DESCRIPTION
* add `AbstractN5SparkTest` class that contains common initialization and cleanup code
* update to n5 2.1.6 to fix intermittent test failures with `DirectoryNotEmptyException`