### PR TITLE
N5 connected components on Spark

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 A small library for processing [N5](https://github.com/saalfeldlab/n5) datasets on an Apache Spark cluster.
 
 Supported operations:
+* thresholding and labeling of connected components
 * resaving using different blocksize / datatype / compression
 * downsampling (isotropic / non-isotropic)
 * max intensity projection
@@ -58,6 +59,53 @@ _JAVA_OPTIONS=-Djdk.net.URLClassPath.disableClassPathURLCheck=true ./build-spark
 The scripts for starting the application are located under `startup-scripts/spark-janelia` and `startup-scripts/spark-local`, and their usage is explained below.
 
 If running locally, you can access the Spark job tracker at http://localhost:4040/ to monitor the progress of the tasks.
+
+
+
+### N5 connected components
+
+<details>
+<summary><b>Run on Janelia cluster</b></summary>
+
+```bash
+spark-janelia/n5-connected-components.py 
+<number of cluster nodes> 
+-n <path to n5 root> 
+-i <input dataset>
+-o <output dataset>
+[--t <min threshold value>]
+[--type <neighborhood type, can be 'diamond' or 'box'>]
+[-b <output block size>]
+[-c <output compression scheme>]
+```
+</details>
+
+<details>
+<summary><b>Run on local machine</b></summary>
+
+```bash
+spark-local/n5-connected-components.py 
+-n <path to n5 root> 
+-i <input dataset>
+-o <output dataset>
+[--t <min threshold value>]
+[--type <neighborhood type, can be 'diamond' or 'box'>]
+[-b <output block size>]
+[-c <output compression scheme>]
+```
+</details>
+
+<br/>
+
+Finds and labels all connected components in a binary mask extracted from the input N5 dataset and saves the relabeled dataset as an `uint64` output dataset.
+
+Optional parameters:
+* **Threshold**: min value in the input data to be included in the binary mask. The condition is `input >= threshold`. If omitted, all input values higher than 0 are included in the binary mask (`input > 0`).
+* **Neighborhood type**: specifies how pixels are grouped into connected components. There are two options:
+  * Diamond (default): only direct neighbors are considered (4-neighborhood in 2D, 6-neighborhood in 3D).
+  * Box (`--type box`): diagonal pixels are considered as well (8-neighborhood in 2D, 26-neighborhood in 3D). It can be used to decrease the number of trivial components.
+* *block size*: comma-separated list. If omitted, the block size of the input dataset is used.
+* *compression scheme*: if omitted, the compression scheme of the input dataset is used.
 
 
 ### N5 converter

--- a/README.md
+++ b/README.md
@@ -95,8 +95,6 @@ spark-local/n5-connected-components.py
 ```
 </details>
 
-<br/>
-
 Finds and labels all connected components in a binary mask extracted from the input N5 dataset and saves the relabeled dataset as an `uint64` output dataset.
 
 Optional parameters:
@@ -146,8 +144,6 @@ spark-local/n5-convert.py
 [--force to overwrite output dataset if already exists]
 ```
 </details>
-
-<br/>
 
 Resaves an N5 dataset possibly changing all or some of the following dataset attributes:
 * *block size*: if omitted, the block size of the input dataset is used.

--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ spark-janelia/n5-connected-components.py
 -n <path to n5 root> 
 -i <input dataset>
 -o <output dataset>
-[-t <min threshold value>]
+[-t <min threshold value for input data>]
 [-s <neighborhood shape, can be 'diamond' or 'box'>]
+[-m <min size of accepted connected components in pixels>]
 [-b <output block size>]
 [-c <output compression scheme>]
 ```
@@ -88,8 +89,9 @@ spark-local/n5-connected-components.py
 -n <path to n5 root> 
 -i <input dataset>
 -o <output dataset>
-[-t <min threshold value>]
+[-t <min threshold value for input data>]
 [-s <neighborhood shape, can be 'diamond' or 'box'>]
+[-m <min size of accepted connected components in pixels>]
 [-b <output block size>]
 [-c <output compression scheme>]
 ```
@@ -102,6 +104,7 @@ Optional parameters:
 * **Neighborhood shape**: specifies how pixels are grouped into connected components. There are two options:
   * Diamond (default): only direct neighbors are considered (4-neighborhood in 2D, 6-neighborhood in 3D).
   * Box (`-s box`): diagonal pixels are considered as well (8-neighborhood in 2D, 26-neighborhood in 3D). It can be used to decrease the number of trivial components.
+* **Min size**: minimum size of a connected component in pixels. If specified, components that contain fewer number of pixels are discarded from the resulting set. By default all components are kept.
 * *block size*: comma-separated list. If omitted, the block size of the input dataset is used.
 * *compression scheme*: if omitted, the compression scheme of the input dataset is used.
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ spark-janelia/n5-connected-components.py
 -n <path to n5 root> 
 -i <input dataset>
 -o <output dataset>
-[--t <min threshold value>]
-[--type <neighborhood type, can be 'diamond' or 'box'>]
+[-t <min threshold value>]
+[-s <neighborhood shape, can be 'diamond' or 'box'>]
 [-b <output block size>]
 [-c <output compression scheme>]
 ```
@@ -88,8 +88,8 @@ spark-local/n5-connected-components.py
 -n <path to n5 root> 
 -i <input dataset>
 -o <output dataset>
-[--t <min threshold value>]
-[--type <neighborhood type, can be 'diamond' or 'box'>]
+[-t <min threshold value>]
+[-s <neighborhood shape, can be 'diamond' or 'box'>]
 [-b <output block size>]
 [-c <output compression scheme>]
 ```
@@ -101,9 +101,9 @@ Finds and labels all connected components in a binary mask extracted from the in
 
 Optional parameters:
 * **Threshold**: min value in the input data to be included in the binary mask. The condition is `input >= threshold`. If omitted, all input values higher than 0 are included in the binary mask (`input > 0`).
-* **Neighborhood type**: specifies how pixels are grouped into connected components. There are two options:
+* **Neighborhood shape**: specifies how pixels are grouped into connected components. There are two options:
   * Diamond (default): only direct neighbors are considered (4-neighborhood in 2D, 6-neighborhood in 3D).
-  * Box (`--type box`): diagonal pixels are considered as well (8-neighborhood in 2D, 26-neighborhood in 3D). It can be used to decrease the number of trivial components.
+  * Box (`-s box`): diagonal pixels are considered as well (8-neighborhood in 2D, 26-neighborhood in 3D). It can be used to decrease the number of trivial components.
 * *block size*: comma-separated list. If omitted, the block size of the input dataset is used.
 * *compression scheme*: if omitted, the compression scheme of the input dataset is used.
 

--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,10 @@
 		</dependency>
 		<dependency>
 			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2-algorithm</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2-ij</artifactId>
 		</dependency>
 		<dependency>

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/N5ConnectedComponentsSpark.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/N5ConnectedComponentsSpark.java
@@ -63,7 +63,28 @@ public class N5ConnectedComponentsSpark
         Box
     }
 
-    public static < T extends RealType< T > & NativeType< T > > void connectedComponents(
+    public static void connectedComponents(
+            final JavaSparkContext sparkContext,
+            final N5WriterSupplier n5Supplier,
+            final String inputDatasetPath,
+            final String outputDatasetPath,
+            final NeighborhoodShapeType neighborhoodShapeType,
+            final Optional< Double > thresholdOptional,
+            final Optional< Long > minSizeOptional ) throws IOException
+    {
+        connectedComponents(
+                sparkContext,
+                n5Supplier,
+                inputDatasetPath,
+                outputDatasetPath,
+                neighborhoodShapeType,
+                thresholdOptional,
+                minSizeOptional,
+                Optional.empty(),
+                Optional.empty() );
+    }
+
+    public static void connectedComponents(
             final JavaSparkContext sparkContext,
             final N5WriterSupplier n5Supplier,
             final String inputDatasetPath,

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/N5ConnectedComponentsSpark.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/N5ConnectedComponentsSpark.java
@@ -247,7 +247,6 @@ public class N5ConnectedComponentsSpark
 
         try ( final JavaSparkContext sparkContext = new JavaSparkContext( new SparkConf()
                 .setAppName( "N5ConnectedComponentsSpark" )
-                .set( "spark.serializer", "org.apache.spark.serializer.KryoSerializer" )
         ) )
         {
             connectedComponents(

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/N5ConnectedComponentsSpark.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/N5ConnectedComponentsSpark.java
@@ -1,0 +1,314 @@
+package org.janelia.saalfeldlab.n5.spark;
+
+import net.imglib2.Cursor;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.labeling.ConnectedComponentAnalysis;
+import net.imglib2.algorithm.neighborhood.DiamondShape;
+import net.imglib2.algorithm.util.unionfind.IntArrayRankedUnionFind;
+import net.imglib2.algorithm.util.unionfind.LongHashMapUnionFind;
+import net.imglib2.algorithm.util.unionfind.UnionFind;
+import net.imglib2.converter.Converters;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.cell.CellGrid;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.logic.BoolType;
+import net.imglib2.type.numeric.IntegerType;
+import net.imglib2.type.numeric.integer.UnsignedLongType;
+import net.imglib2.util.Intervals;
+import net.imglib2.view.Views;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.broadcast.Broadcast;
+import org.janelia.saalfeldlab.n5.*;
+import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
+import org.janelia.saalfeldlab.n5.spark.supplier.N5ReaderSupplier;
+import org.janelia.saalfeldlab.n5.spark.supplier.N5WriterSupplier;
+import org.janelia.saalfeldlab.n5.spark.util.CmdUtils;
+import org.janelia.saalfeldlab.n5.spark.util.GridUtils;
+import org.janelia.saalfeldlab.n5.spark.util.N5Compression;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+public class N5ConnectedComponentsSpark
+{
+    private static final int MAX_PARTITIONS = 15000;
+
+    public static < T extends IntegerType< T > & NativeType< T > > void connectedComponents(
+            final JavaSparkContext sparkContext,
+            final N5WriterSupplier n5Supplier,
+            final String inputDatasetPath,
+            final String outputDatasetPath,
+            final Optional< int[] > blockSizeOptional,
+            final Optional< Compression > compressionOptional ) throws IOException
+    {
+        final N5Writer n5 = n5Supplier.get();
+        if ( n5.datasetExists( outputDatasetPath ) )
+            throw new RuntimeException( "Output dataset already exists: " + outputDatasetPath );
+
+        final String tempDatasetPath = outputDatasetPath + "-blockwise";
+        if ( n5.datasetExists( tempDatasetPath ) )
+            throw new RuntimeException( "Temporary dataset already exists: " + tempDatasetPath );
+
+        final DatasetAttributes inputAttributes = n5.getDatasetAttributes( inputDatasetPath );
+        final long[] dimensions = inputAttributes.getDimensions();
+        final int[] inputBlockSize = inputAttributes.getBlockSize();
+        final Compression inputCompression = inputAttributes.getCompression();
+        final int[] outputBlockSize = blockSizeOptional.isPresent() ? blockSizeOptional.get() : inputBlockSize;
+        final Compression outputCompression = compressionOptional.isPresent() ? compressionOptional.get() : inputCompression;
+
+        n5.createDataset( tempDatasetPath, dimensions, outputBlockSize, DataType.UINT64, outputCompression );
+        generateBlockwiseLabeling( sparkContext, n5Supplier, inputDatasetPath, tempDatasetPath );
+
+        final UnionFind unionFind = findTouchingBlockwiseComponents( sparkContext, n5Supplier, tempDatasetPath );
+
+        n5.createDataset( outputDatasetPath, dimensions, outputBlockSize, DataType.UINT64, outputCompression );
+        relabelBlockwiseComponents( sparkContext, n5Supplier, tempDatasetPath, outputDatasetPath, unionFind );
+
+        N5RemoveSpark.remove( sparkContext, n5Supplier, tempDatasetPath );
+    }
+
+    private static < T extends IntegerType< T > & NativeType< T > > void generateBlockwiseLabeling(
+            final JavaSparkContext sparkContext,
+            final N5WriterSupplier n5Supplier,
+            final String inputDatasetPath,
+            final String tempDatasetPath ) throws IOException
+    {
+        final DatasetAttributes outputDatasetAttributes = n5Supplier.get().getDatasetAttributes( tempDatasetPath );
+        final long[] dimensions = outputDatasetAttributes.getDimensions();
+        final int[] blockSize = outputDatasetAttributes.getBlockSize();
+
+        final long numOutputBlocks = Intervals.numElements( new CellGrid( dimensions, blockSize ).getGridDimensions() );
+        final List< Long > outputBlockIndexes = LongStream.range( 0, numOutputBlocks ).boxed().collect( Collectors.toList() );
+
+        sparkContext.parallelize( outputBlockIndexes, Math.min( outputBlockIndexes.size(), MAX_PARTITIONS ) ).foreach( outputBlockIndex ->
+        {
+            final Interval outputBlockInterval = GridUtils.getCellInterval( new CellGrid( dimensions, blockSize ), outputBlockIndex );
+
+            final N5Writer n5Local = n5Supplier.get();
+            final RandomAccessibleInterval< T > input = N5Utils.open( n5Local, inputDatasetPath );
+            final RandomAccessibleInterval< T > inputBlock = Views.interval( input, outputBlockInterval );
+
+            final RandomAccessibleInterval< UnsignedLongType > outputBlock = Views.translate(
+                    ArrayImgs.unsignedLongs( Intervals.dimensionsAsLongArray( outputBlockInterval ) ),
+                    Intervals.minAsLongArray( outputBlockInterval ) );
+
+            final RandomAccessibleInterval< BoolType > binaryInput = Converters.convert(
+                    inputBlock,
+                    ( in, out ) -> out.set( in.getIntegerLong() != 0 ),
+                    new BoolType() );
+
+            ConnectedComponentAnalysis.connectedComponents(
+                    binaryInput,
+                    outputBlock,
+                    new DiamondShape( 1 ),
+                    n -> new IntArrayRankedUnionFind( ( int ) n ),
+                    ConnectedComponentAnalysis.idFromIntervalIndexer( outputBlockInterval ),
+                    root -> root + 1 );
+
+            N5Utils.saveNonEmptyBlock(
+                    outputBlock,
+                    n5Local,
+                    tempDatasetPath,
+                    new UnsignedLongType() );
+        } );
+    }
+
+    private static UnionFind findTouchingBlockwiseComponents(
+            final JavaSparkContext sparkContext,
+            final N5ReaderSupplier n5Supplier,
+            final String tempDatasetPath ) throws IOException
+    {
+        final DatasetAttributes outputDatasetAttributes = n5Supplier.get().getDatasetAttributes( tempDatasetPath );
+        final long[] dimensions = outputDatasetAttributes.getDimensions();
+        final int[] blockSize = outputDatasetAttributes.getBlockSize();
+
+        final long numBlocks = Intervals.numElements( new CellGrid( dimensions, blockSize ).getGridDimensions() );
+        final List< Long > blockIndexes = LongStream.range( 0, numBlocks ).boxed().collect( Collectors.toList() );
+
+        final Set< List< Long > > touchingPairs = sparkContext
+                .parallelize( blockIndexes, Math.min( blockIndexes.size(), MAX_PARTITIONS ) )
+                .map( outputBlockIndex ->
+        {
+            final Interval blockInterval = GridUtils.getCellInterval( new CellGrid( dimensions, blockSize ), outputBlockIndex );
+            final N5Reader n5Local = n5Supplier.get();
+            final RandomAccessibleInterval< UnsignedLongType > labeling = N5Utils.open( n5Local, tempDatasetPath );
+            final RandomAccessibleInterval< UnsignedLongType > block = Views.interval( labeling, blockInterval );
+
+            final Set< List< Long > > blockTouchingPairs = new HashSet<>();
+            for ( int d = 0; d < block.numDimensions(); ++d )
+            {
+                // get the block interval and expand it by 1 px in all dimensions to be able to access the first planes of the next block
+                final long[] expansion = new long[ block.numDimensions() ];
+                expansion[ d ] = 1;
+                final RandomAccessibleInterval< UnsignedLongType > expandedBlock = Views.expandZero( block, expansion );
+
+                final Cursor< UnsignedLongType >[] planeCursors = new Cursor[ 2 ];
+                for ( int i = 0; i < 2; ++i )
+                {
+                    final RandomAccessibleInterval< UnsignedLongType > plane = Views.hyperSlice(expandedBlock, d, blockInterval.max(d) + i);
+                    planeCursors[ i ] = Views.flatIterable( plane ).cursor();
+                }
+
+                // find correspondences between touching ids in the current block and in the next block
+                while ( planeCursors[ 0 ].hasNext() || planeCursors[ 1 ].hasNext() )
+                {
+                    final long x = planeCursors[ 0 ].next().getLong();
+                    final long y = planeCursors[ 1 ].next().getLong();
+                    if ( x != 0 && y != 0 )
+                        blockTouchingPairs.add( Arrays.asList( x, y ) );
+                }
+            }
+            return blockTouchingPairs;
+        } )
+                .treeReduce(
+                        ( a, b ) -> { a.addAll( b ); return a; },
+                        Integer.MAX_VALUE // max possible aggregation depth
+        );
+
+        // perform union find to merge all touching objects
+        long elapsedMsec = System.currentTimeMillis();
+
+        final UnionFind unionFind = new LongHashMapUnionFind();
+        for ( final List< Long > touchingPair : touchingPairs )
+            unionFind.join( touchingPair.get( 0 ), touchingPair.get( 1 ) );
+
+        elapsedMsec = System.currentTimeMillis() - elapsedMsec;
+        System.out.println( String.format(
+                "Global union-find took %d seconds. Total number of components: %d",
+                elapsedMsec / 1000,
+                unionFind.setCount() ) );
+
+        return unionFind;
+    }
+
+    private static void relabelBlockwiseComponents(
+            final JavaSparkContext sparkContext,
+            final N5WriterSupplier n5Supplier,
+            final String tempDatasetPath,
+            final String outputDatasetPath,
+            final UnionFind unionFind ) throws IOException
+    {
+        final DatasetAttributes outputDatasetAttributes = n5Supplier.get().getDatasetAttributes( outputDatasetPath );
+        final long[] dimensions = outputDatasetAttributes.getDimensions();
+        final int[] blockSize = outputDatasetAttributes.getBlockSize();
+
+        final long numBlocks = Intervals.numElements( new CellGrid( dimensions, blockSize ).getGridDimensions() );
+        final List< Long > blockIndexes = LongStream.range( 0, numBlocks ).boxed().collect( Collectors.toList() );
+
+        final Broadcast< UnionFind > unionFindBroadcast = sparkContext.broadcast( unionFind );
+
+        sparkContext.parallelize( blockIndexes, Math.min( blockIndexes.size(), MAX_PARTITIONS ) ).foreach( outputBlockIndex ->
+        {
+            final Interval blockInterval = GridUtils.getCellInterval( new CellGrid( dimensions, blockSize ), outputBlockIndex );
+            final N5Writer n5Local = n5Supplier.get();
+            final UnionFind unionFindLocal = unionFindBroadcast.getValue();
+            final RandomAccessibleInterval<UnsignedLongType> input = N5Utils.open( n5Local, tempDatasetPath );
+            final RandomAccessibleInterval<UnsignedLongType> inputBlock = Views.interval( input, blockInterval );
+
+            final RandomAccessibleInterval< UnsignedLongType > outputBlock = Views.translate(
+                    ArrayImgs.unsignedLongs( Intervals.dimensionsAsLongArray( blockInterval ) ),
+                    Intervals.minAsLongArray( blockInterval ) );
+
+            final Cursor< UnsignedLongType > inputCursor = Views.flatIterable( inputBlock ).cursor();
+            final Cursor< UnsignedLongType > outputCursor = Views.flatIterable( outputBlock ).cursor();
+            while ( inputCursor.hasNext() || outputCursor.hasNext() )
+            {
+                final long inputId = inputCursor.next().get();
+                final UnsignedLongType outputVal = outputCursor.next();
+                if ( inputId != 0 )
+                    outputVal.set( unionFindLocal.findRoot( inputId ) );
+            }
+
+            N5Utils.saveNonEmptyBlock(
+                    outputBlock,
+                    n5Local,
+                    outputDatasetPath,
+                    new UnsignedLongType() );
+        } );
+
+        unionFindBroadcast.destroy();
+    }
+
+    public static void main( final String... args ) throws IOException
+    {
+        final Arguments parsedArgs = new Arguments( args );
+        if ( !parsedArgs.parsedSuccessfully() )
+            System.exit( 1 );
+
+        try ( final JavaSparkContext sparkContext = new JavaSparkContext( new SparkConf()
+                .setAppName( "N5ConnectedComponentsSpark" )
+                .set( "spark.serializer", "org.apache.spark.serializer.KryoSerializer" )
+        ) )
+        {
+            connectedComponents(
+                    sparkContext,
+                    () -> new N5FSWriter( parsedArgs.getN5Path() ),
+                    parsedArgs.getInputDatasetPath(),
+                    parsedArgs.getOutputDatasetPath(),
+                    Optional.ofNullable( parsedArgs.getBlockSize() ),
+                    Optional.ofNullable( parsedArgs.getCompression() )
+            );
+        }
+
+        System.out.println( System.lineSeparator() + "Done" );
+    }
+
+    private static class Arguments implements Serializable
+    {
+        private static final long serialVersionUID = 4847292347478989514L;
+
+        @Option(name = "-n", aliases = { "-n", "--n5Path" }, required = true,
+                usage = "Path to the N5 container.")
+        private String n5Path;
+
+        @Option(name = "-i", aliases = { "--inputDatasetPath" }, required = true,
+                usage = "Path to the input binary mask dataset within the N5 container (e.g. data/group/s0).")
+        private String inputDatasetPath;
+
+        @Option(name = "-o", aliases = { "--outputDatasetPath" }, required = true,
+                usage = "Output dataset path.")
+        private String outputDatasetPath;
+
+        @Option(name = "-b", aliases = { "--blockSize" }, required = false,
+                usage = "Block size for the output dataset (same as input dataset block size by default).")
+        private String blockSizeStr;
+
+        @Option(name = "-c", aliases = { "--compression" }, required = false,
+                usage = "Compression to be used for the converted dataset (same as input dataset compression by default).")
+        private N5Compression n5Compression;
+
+        private int[] blockSize;
+        private boolean parsedSuccessfully = false;
+
+        public Arguments( final String... args )
+        {
+            final CmdLineParser parser = new CmdLineParser( this );
+            try
+            {
+                parser.parseArgument( args );
+                blockSize = blockSizeStr != null ? CmdUtils.parseIntArray( blockSizeStr ) : null;
+                parsedSuccessfully = true;
+            }
+            catch ( final CmdLineException e )
+            {
+                System.err.println( e.getMessage() );
+                parser.printUsage( System.err );
+            }
+        }
+
+        public boolean parsedSuccessfully() { return parsedSuccessfully; }
+        public String getN5Path() { return n5Path; }
+        public String getInputDatasetPath() { return inputDatasetPath; }
+        public String getOutputDatasetPath() { return outputDatasetPath; }
+        public int[] getBlockSize() { return blockSize; }
+        public Compression getCompression() { return n5Compression != null ? n5Compression.get() : null; }
+    }
+}

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/N5ConnectedComponentsSpark.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/N5ConnectedComponentsSpark.java
@@ -101,6 +101,12 @@ public class N5ConnectedComponentsSpark
                     ( in, out ) -> out.set( in.getIntegerLong() != 0 ),
                     new BoolType() );
 
+            boolean isEmpty = true;
+            for ( final Iterator< BoolType > it = Views.iterable( binaryInput ).iterator(); it.hasNext() && isEmpty; )
+                isEmpty &= !it.next().get();
+            if ( isEmpty )
+                return;
+
             final RandomAccessibleInterval< UnsignedLongType > outputBlock = Views.translate(
                     ArrayImgs.unsignedLongs( Intervals.dimensionsAsLongArray( outputBlockInterval ) ),
                     Intervals.minAsLongArray( outputBlockInterval ) );

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/N5ConnectedComponentsSpark.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/N5ConnectedComponentsSpark.java
@@ -15,7 +15,7 @@ import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.img.cell.CellGrid;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.logic.BoolType;
-import net.imglib2.type.numeric.IntegerType;
+import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.UnsignedLongType;
 import net.imglib2.util.Intervals;
 import net.imglib2.view.Views;
@@ -61,7 +61,7 @@ public class N5ConnectedComponentsSpark
         Box
     }
 
-    public static < T extends IntegerType< T > & NativeType< T > > void connectedComponents(
+    public static < T extends RealType< T > & NativeType< T > > void connectedComponents(
             final JavaSparkContext sparkContext,
             final N5WriterSupplier n5Supplier,
             final String inputDatasetPath,
@@ -112,7 +112,7 @@ public class N5ConnectedComponentsSpark
         N5RemoveSpark.remove( sparkContext, n5Supplier, tempDatasetPath );
     }
 
-    private static < T extends IntegerType< T > & NativeType< T > > void generateBlockwiseLabeling(
+    private static < T extends RealType< T > & NativeType< T > > void generateBlockwiseLabeling(
             final JavaSparkContext sparkContext,
             final N5WriterSupplier n5Supplier,
             final String inputDatasetPath,
@@ -136,7 +136,7 @@ public class N5ConnectedComponentsSpark
 
             final RandomAccessibleInterval< BoolType > binaryInput = Converters.convert(
                     inputBlock,
-                    ( in, out ) -> out.set( in.getIntegerLong() != 0 ),
+                    ( in, out ) -> out.set( in.getRealDouble() > 0 ),
                     new BoolType() );
 
             boolean isEmpty = true;

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/util/GridUtils.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/util/GridUtils.java
@@ -1,0 +1,28 @@
+package org.janelia.saalfeldlab.n5.spark.util;
+
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
+import net.imglib2.img.cell.CellGrid;
+
+import java.util.Arrays;
+
+public class GridUtils
+{
+    public static Interval getCellInterval(final CellGrid grid, final long cellIndex)
+    {
+        final long[] cellMin = new long[grid.numDimensions()], cellMax = new long[grid.numDimensions()];
+        final int[] cellDims = new int[grid.numDimensions()];
+        grid.getCellDimensions(cellIndex, cellMin, cellDims);
+        Arrays.setAll(cellMax, d -> cellMin[d] + cellDims[d] - 1);
+        return new FinalInterval(cellMin, cellMax);
+    }
+
+    public static Interval getCellInterval(final CellGrid grid, final long[] cellPosition)
+    {
+        final long[] cellMin = new long[grid.numDimensions()], cellMax = new long[grid.numDimensions()];
+        final int[] cellDims = new int[grid.numDimensions()];
+        grid.getCellDimensions(cellPosition, cellMin, cellDims);
+        Arrays.setAll(cellMax, d -> cellMin[d] + cellDims[d] - 1);
+        return new FinalInterval(cellMin, cellMax);
+    }
+}

--- a/src/test/java/org/janelia/saalfeldlab/n5/spark/N5ConnectedComponentsSparkTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/spark/N5ConnectedComponentsSparkTest.java
@@ -140,6 +140,7 @@ public class N5ConnectedComponentsSparkTest extends AbstractN5SparkTest
                     relabeledDatasetPath,
                     typeAndExpectedEntry.getKey(),
                     Optional.empty(),
+                    Optional.empty(),
                     Optional.empty() );
 
             Assert.assertTrue( n5.datasetExists( datasetPath ) );

--- a/src/test/java/org/janelia/saalfeldlab/n5/spark/N5ConnectedComponentsSparkTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/spark/N5ConnectedComponentsSparkTest.java
@@ -7,58 +7,22 @@ import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.integer.UnsignedLongType;
 import net.imglib2.util.Intervals;
 import net.imglib2.view.Views;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.spark.SparkConf;
-import org.apache.spark.api.java.JavaSparkContext;
 import org.janelia.saalfeldlab.n5.GzipCompression;
 import org.janelia.saalfeldlab.n5.N5FSWriter;
 import org.janelia.saalfeldlab.n5.N5Writer;
 import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
-import org.janelia.saalfeldlab.n5.spark.supplier.N5WriterSupplier;
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-public class N5ConnectedComponentsSparkTest
+public class N5ConnectedComponentsSparkTest extends AbstractN5SparkTest
 {
-    static private final String basePath = System.getProperty("user.home") + "/.n5-spark-test-" + RandomStringUtils.randomAlphanumeric(5);
     static private final String datasetPath = "data";
     static private final String relabeledDatasetPath = "data-relabeled";
-
-    static private final N5WriterSupplier n5Supplier = () -> new N5FSWriter( basePath );
-
-    private JavaSparkContext sparkContext;
-
-    @Before
-    public void setUp() throws IOException
-    {
-        // cleanup in case the test has failed
-        tearDown();
-
-        sparkContext = new JavaSparkContext( new SparkConf()
-                .setMaster( "local[*]" )
-                .setAppName( "N5ConnectedComponentsTest" )
-                .set( "spark.serializer", "org.apache.spark.serializer.KryoSerializer" )
-        );
-    }
-
-    @After
-    public void tearDown() throws IOException
-    {
-        if ( sparkContext != null )
-            sparkContext.close();
-
-        if ( Files.exists( Paths.get( basePath ) ) )
-            Assert.assertTrue( n5Supplier.get().remove() );
-    }
 
     @Test
     public void test1() throws IOException
@@ -80,7 +44,7 @@ public class N5ConnectedComponentsSparkTest
 
     private void runTest( final int[] blockSize ) throws IOException
     {
-        final N5Writer n5 = n5Supplier.get();
+        final N5Writer n5 = new N5FSWriter( basePath );
         final long[] dimensions = new long[] { 4, 4, 3 };
 
         final int[] data = {
@@ -104,7 +68,7 @@ public class N5ConnectedComponentsSparkTest
 
         N5ConnectedComponentsSpark.connectedComponents(
                 sparkContext,
-                n5Supplier,
+                () -> new N5FSWriter( basePath ),
                 datasetPath,
                 relabeledDatasetPath,
                 Optional.empty(),

--- a/src/test/java/org/janelia/saalfeldlab/n5/spark/N5ConnectedComponentsSparkTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/spark/N5ConnectedComponentsSparkTest.java
@@ -44,7 +44,7 @@ public class N5ConnectedComponentsSparkTest
         tearDown();
 
         sparkContext = new JavaSparkContext( new SparkConf()
-                .setMaster( "local[1]" )
+                .setMaster( "local[*]" )
                 .setAppName( "N5ConnectedComponentsTest" )
                 .set( "spark.serializer", "org.apache.spark.serializer.KryoSerializer" )
         );

--- a/src/test/java/org/janelia/saalfeldlab/n5/spark/N5ConnectedComponentsSparkTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/spark/N5ConnectedComponentsSparkTest.java
@@ -140,7 +140,6 @@ public class N5ConnectedComponentsSparkTest extends AbstractN5SparkTest
                     relabeledDatasetPath,
                     shapeTypeAndExpectedEntry.getKey(),
                     Optional.empty(),
-                    Optional.empty(),
                     Optional.empty() );
 
             Assert.assertTrue( n5.datasetExists( datasetPath ) );

--- a/src/test/java/org/janelia/saalfeldlab/n5/spark/N5ConnectedComponentsSparkTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/spark/N5ConnectedComponentsSparkTest.java
@@ -74,11 +74,11 @@ public class N5ConnectedComponentsSparkTest extends AbstractN5SparkTest
 
         N5Utils.save( ArrayImgs.ints( data, dimensions ), n5, datasetPath, blockSize, new GzipCompression() );
 
-        final Map< N5ConnectedComponentsSpark.NeighborhoodType, int[] > typeAndExpected = new HashMap<>();
-        typeAndExpected.put( N5ConnectedComponentsSpark.NeighborhoodType.Diamond, data ); // single component
-        typeAndExpected.put( N5ConnectedComponentsSpark.NeighborhoodType.Box, data ); // single component
+        final Map< N5ConnectedComponentsSpark.NeighborhoodShapeType, int[] > shapeTypeAndExpected = new HashMap<>();
+        shapeTypeAndExpected.put( N5ConnectedComponentsSpark.NeighborhoodShapeType.Diamond, data ); // single component
+        shapeTypeAndExpected.put( N5ConnectedComponentsSpark.NeighborhoodShapeType.Box, data ); // single component
 
-        runTest( n5, typeAndExpected );
+        runTest( n5, shapeTypeAndExpected );
     }
 
     private void runTest3D( final int[] blockSize ) throws IOException
@@ -105,7 +105,7 @@ public class N5ConnectedComponentsSparkTest extends AbstractN5SparkTest
 
         N5Utils.save( ArrayImgs.ints( data, dimensions ), n5, datasetPath, blockSize, new GzipCompression() );
 
-        final int[] expectedDiamondNeighborhoodType = {
+        final int[] expectedForDiamondNeighborhoodShapeType = {
                 0, 1, 1, 0,
                 1, 0, 1, 1,
                 1, 1, 1, 0,
@@ -122,23 +122,23 @@ public class N5ConnectedComponentsSparkTest extends AbstractN5SparkTest
                 0, 1, 0, 2,
         };
 
-        final Map< N5ConnectedComponentsSpark.NeighborhoodType, int[] > typeAndExpected = new HashMap<>();
-        typeAndExpected.put( N5ConnectedComponentsSpark.NeighborhoodType.Diamond, expectedDiamondNeighborhoodType );
-        typeAndExpected.put( N5ConnectedComponentsSpark.NeighborhoodType.Box, data ); // single component
+        final Map< N5ConnectedComponentsSpark.NeighborhoodShapeType, int[] > shapeTypeAndExpected = new HashMap<>();
+        shapeTypeAndExpected.put( N5ConnectedComponentsSpark.NeighborhoodShapeType.Diamond, expectedForDiamondNeighborhoodShapeType );
+        shapeTypeAndExpected.put( N5ConnectedComponentsSpark.NeighborhoodShapeType.Box, data ); // single component
 
-        runTest( n5, typeAndExpected );
+        runTest( n5, shapeTypeAndExpected );
     }
 
-    private void runTest( final N5Writer n5, final Map< N5ConnectedComponentsSpark.NeighborhoodType, int[] > typeAndExpected ) throws IOException
+    private void runTest( final N5Writer n5, final Map< N5ConnectedComponentsSpark.NeighborhoodShapeType, int[] > shapeTypeAndExpected ) throws IOException
     {
-        for ( final Map.Entry< N5ConnectedComponentsSpark.NeighborhoodType, int[] > typeAndExpectedEntry : typeAndExpected.entrySet() )
+        for ( final Map.Entry< N5ConnectedComponentsSpark.NeighborhoodShapeType, int[] > shapeTypeAndExpectedEntry : shapeTypeAndExpected.entrySet() )
         {
             N5ConnectedComponentsSpark.connectedComponents(
                     sparkContext,
                     () -> new N5FSWriter( basePath ),
                     datasetPath,
                     relabeledDatasetPath,
-                    typeAndExpectedEntry.getKey(),
+                    shapeTypeAndExpectedEntry.getKey(),
                     Optional.empty(),
                     Optional.empty(),
                     Optional.empty() );
@@ -147,7 +147,7 @@ public class N5ConnectedComponentsSparkTest extends AbstractN5SparkTest
             Assert.assertTrue( n5.datasetExists( relabeledDatasetPath ) );
 
             final RandomAccessibleInterval< UnsignedLongType > output = N5Utils.open( n5, relabeledDatasetPath );
-            Assert.assertArrayEquals( typeAndExpectedEntry.getValue(), relabel( output ) );
+            Assert.assertArrayEquals( shapeTypeAndExpectedEntry.getValue(), relabel( output ) );
 
             Assert.assertTrue( n5.remove( relabeledDatasetPath ) );
         }

--- a/src/test/java/org/janelia/saalfeldlab/n5/spark/N5ConnectedComponentsSparkTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/spark/N5ConnectedComponentsSparkTest.java
@@ -1,0 +1,158 @@
+package org.janelia.saalfeldlab.n5.spark;
+
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.IntegerType;
+import net.imglib2.type.numeric.integer.UnsignedLongType;
+import net.imglib2.util.Intervals;
+import net.imglib2.view.Views;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.janelia.saalfeldlab.n5.GzipCompression;
+import org.janelia.saalfeldlab.n5.N5FSWriter;
+import org.janelia.saalfeldlab.n5.N5Writer;
+import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
+import org.janelia.saalfeldlab.n5.spark.supplier.N5WriterSupplier;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class N5ConnectedComponentsSparkTest
+{
+    static private final String basePath = System.getProperty("user.home") + "/.n5-spark-test-" + RandomStringUtils.randomAlphanumeric(5);
+    static private final String datasetPath = "data";
+    static private final String relabeledDatasetPath = "data-relabeled";
+
+    static private final N5WriterSupplier n5Supplier = () -> new N5FSWriter( basePath );
+
+    private JavaSparkContext sparkContext;
+
+    @Before
+    public void setUp() throws IOException
+    {
+        // cleanup in case the test has failed
+        tearDown();
+
+        sparkContext = new JavaSparkContext( new SparkConf()
+                .setMaster( "local[1]" )
+                .setAppName( "N5ConnectedComponentsTest" )
+                .set( "spark.serializer", "org.apache.spark.serializer.KryoSerializer" )
+        );
+    }
+
+    @After
+    public void tearDown() throws IOException
+    {
+        if ( sparkContext != null )
+            sparkContext.close();
+
+        if ( Files.exists( Paths.get( basePath ) ) )
+            Assert.assertTrue( n5Supplier.get().remove() );
+    }
+
+    @Test
+    public void test1() throws IOException
+    {
+        runTest( new int[] { 1, 1, 1 } );
+    }
+
+    @Test
+    public void test2() throws IOException
+    {
+        runTest( new int[] { 2, 2, 2 } );
+    }
+
+    @Test
+    public void test3() throws IOException
+    {
+        runTest( new int[] { 3, 4, 5 } );
+    }
+
+    private void runTest( final int[] blockSize ) throws IOException
+    {
+        final N5Writer n5 = n5Supplier.get();
+        final long[] dimensions = new long[] { 4, 4, 3 };
+
+        final int[] data = {
+                0, 1, 1, 0,
+                1, 0, 1, 1,
+                1, 1, 1, 0,
+                0, 1, 0, 1,
+
+                0, 1, 0, 1,
+                0, 1, 1, 0,
+                1, 0, 1, 0,
+                0, 0, 0, 1,
+
+                1, 1, 0, 1,
+                0, 0, 0, 1,
+                1, 1, 1, 0,
+                0, 1, 0, 1,
+        };
+
+        N5Utils.save( ArrayImgs.ints( data, dimensions ), n5, datasetPath, blockSize, new GzipCompression() );
+
+        N5ConnectedComponentsSpark.connectedComponents(
+                sparkContext,
+                n5Supplier,
+                datasetPath,
+                relabeledDatasetPath,
+                Optional.empty(),
+                Optional.empty() );
+
+        Assert.assertTrue( n5.datasetExists( datasetPath ) );
+        Assert.assertTrue( n5.datasetExists( relabeledDatasetPath ) );
+
+        final int[] expected = {
+                0, 1, 1, 0,
+                1, 0, 1, 1,
+                1, 1, 1, 0,
+                0, 1, 0, 2,
+
+                0, 1, 0, 3,
+                0, 1, 1, 0,
+                1, 0, 1, 0,
+                0, 0, 0, 2,
+
+                1, 1, 0, 3,
+                0, 0, 0, 3,
+                1, 1, 1, 0,
+                0, 1, 0, 2,
+        };
+
+        final RandomAccessibleInterval< UnsignedLongType > output = N5Utils.open( n5, relabeledDatasetPath );
+        Assert.assertArrayEquals( expected, relabel( output ) );
+    }
+
+    private int[] relabel( final RandomAccessibleInterval< ? extends IntegerType<?>> labelsImg )
+    {
+        final int[] relabeledData = new int[ ( int ) Intervals.numElements( labelsImg ) ];
+        int index = 0;
+        final Map< Long, Integer > mapping = new HashMap<>();
+
+        final Cursor< ? extends IntegerType<?>> outputCursor = Views.flatIterable( labelsImg ).cursor();
+        while ( outputCursor.hasNext() )
+        {
+            final long id = outputCursor.next().getIntegerLong();
+            if ( id != 0 )
+            {
+                if ( !mapping.containsKey( id ) )
+                    mapping.put( id, mapping.size() + 1 );
+                relabeledData[ index ] = mapping.get( id );
+            }
+            ++index;
+        }
+
+        return relabeledData;
+    }
+}

--- a/startup-scripts/spark-janelia/n5-connected-components.py
+++ b/startup-scripts/spark-janelia/n5-connected-components.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import subprocess
+
+sys.dont_write_bytecode = True
+curr_script_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.dirname(curr_script_dir))
+from jar_path_util import get_provided_jar_path
+bin_path = get_provided_jar_path()
+
+flintstone_relpath = os.path.join('flintstone', 'flintstone-lsd.sh')
+flintstone_path = os.path.join(curr_script_dir, flintstone_relpath)
+
+os.environ['RUNTIME'] = '24:00'
+
+nodes = int(sys.argv[1])
+
+subprocess.call([flintstone_path, str(nodes), bin_path, 'org.janelia.saalfeldlab.n5.spark.N5ConnectedComponentsSpark'] + sys.argv[2:])

--- a/startup-scripts/spark-local/n5-connected-components.py
+++ b/startup-scripts/spark-local/n5-connected-components.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import subprocess
+
+sys.dont_write_bytecode = True
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from jar_path_util import get_local_jar_path
+bin_path = get_local_jar_path()
+
+subprocess.call(['java', '-Dspark.master=local[*]', '-cp', bin_path, 'org.janelia.saalfeldlab.n5.spark.N5ConnectedComponentsSpark'] + sys.argv[1:])


### PR DESCRIPTION
Adds distributed connected components utility for N5 datasets.

The algorithm is inspired by synapse counting method and @davidackerman's connected components implementation for cosem: in the first pass the components are labeled in each block separately, then touching components are merged across the blocks.

The startup scripts are available for cluster and local use and are named `n5-connected-components.py`.

* Input dataset is treated as a binary mask by default (all input values `input > 0` are included in the mask).
* There is also an optional parameter `-t` / `--threshold` that specifies the min input value to be included in the mask. If it's set, the condition for the binary mask will be `input >= threshold`.
* There are two types of neighborhood shape that change how pixels are grouped into components:
  * Diamond (default): only direct neighbors are considered (4-neighborhood in 2D, 6-neighborhood in 3D).
  * Box: diagonal pixels are considered as well (8-neighborhood in 2D, 26-neighborhood in 3D). It can be used to decrease the number of trivial components. (`-s box` / `--shape box`)
* There is an option of filtering resulting connected components by their size (in pixels). The minimum size can be specified with `-m` / `--minSize`, and all components that contain fewer pixels will be discarded from the result. It could also be useful for minimizing the number of trivial components. By default there is no filtering, so all components are kept.
* Block size and compression of the output dataset will be the same as the input dataset by default, but they can be overridden with the optional parameters.

It can be also used together with [paintera-conversion-helper](https://github.com/saalfeldlab/paintera-conversion-helper) to convert a raw dataset into a paintera-compatible multiscale label source.

Ideas for future improvements:
* Relabel all resulting components from `1` to `N`. Currently, the IDs are calculated from the pixel indices in the volume which could be very large numbers (though, they still fit into uint64 so it's not a problem).