### PR TITLE
Support saving TIFF files to an abstract backend (potentially cloud)

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/util/TiffUtils.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/util/TiffUtils.java
@@ -1,5 +1,8 @@
 package org.janelia.saalfeldlab.n5.spark.util;
 
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.file.Paths;
 import java.util.Arrays;
 
 import ij.IJ;
@@ -8,35 +11,70 @@ import loci.plugins.LociExporter;
 
 public class TiffUtils
 {
-	public static enum TiffCompression
+	public enum TiffCompression
 	{
 		NONE,
 		LZW
 	}
 
-	public static void saveAsTiff( final ImagePlus imp, final String outputPath, final TiffCompression compression )
+	public interface TiffReader extends Serializable
 	{
-		workaroundImagePlusNSlices( imp );
-		switch ( compression )
+		ImagePlus openTiff( final String inputPath ) throws IOException;
+	}
+
+	// TODO: can be replaced by DataProvider + PathResolver class hierarchy that is currently implemented in stitching-spark
+	public interface TiffWriter extends Serializable
+	{
+		void saveTiff( final ImagePlus imp, final String outputPath, final TiffCompression compression ) throws IOException;
+
+		void createDirs( final String path ) throws IOException;
+
+		String combinePaths( final String basePath, final String other );
+	}
+
+	public static class FileTiffReader implements TiffReader
+	{
+		@Override
+		public ImagePlus openTiff( final String inputPath )
 		{
-		case NONE:
-			IJ.saveAsTiff( imp, outputPath );
-			break;
-		case LZW:
-			final LociExporter lociExporter = new LociExporter();
-			lociExporter.setup( String.format( "outfile=[%s] compression=[LZW] windowless=[TRUE]", outputPath ), imp );
-			lociExporter.run( null );
-		default:
-			break;
+			final ImagePlus imp = IJ.openImage( inputPath );
+			if ( imp != null )
+				workaroundImagePlusNSlices( imp );
+			return imp;
 		}
 	}
 
-	public static ImagePlus openTiff( final String filepath )
+	public static class FileTiffWriter implements TiffWriter
 	{
-		final ImagePlus imp = IJ.openImage( filepath );
-		if ( imp != null )
+		@Override
+		public void saveTiff( final ImagePlus imp, final String outputPath, final TiffCompression compression)
+		{
 			workaroundImagePlusNSlices( imp );
-		return imp;
+			switch ( compression )
+			{
+			case NONE:
+				IJ.saveAsTiff( imp, outputPath );
+				break;
+			case LZW:
+				final LociExporter lociExporter = new LociExporter();
+				lociExporter.setup( String.format( "outfile=[%s] compression=[LZW] windowless=[TRUE]", outputPath ), imp );
+				lociExporter.run( null );
+			default:
+				break;
+			}
+		}
+
+		@Override
+		public void createDirs( final String path )
+		{
+			Paths.get( path ).toFile().mkdirs();
+		}
+
+		@Override
+		public String combinePaths( final String basePath, final String other )
+		{
+			return Paths.get( basePath, other ).toString();
+		}
 	}
 
 	private static void workaroundImagePlusNSlices( final ImagePlus imp )


### PR DESCRIPTION
* Added new interfaces `TiffReader` and `TiffWriter` (here we mostly care about writing)
* Added filesystem-based implementations `FileTiffReader` and `FileTiffWriter`
* Enabled these interfaces in `N5ToSliceTIFF` and `N5MaxProjection`

The caller code can now create its own implementation of `TiffWriter` to enable saving TIFF files to a different backend, for example, cloud storage.

`TiffReader` is not quite complete yet, and to make use of it in `SliceTIFFToN5` we would need to add extend its functionality with file listing, walking a subdirectory recursively, etc. Some of this functionality is already implemented in [stitching-spark](https://github.com/saalfeldlab/stitching-spark) ([DataProvider](https://github.com/saalfeldlab/stitching-spark/blob/master/src/main/java/org/janelia/dataaccess/DataProvider.java) class hierarchy), so it could be moved here in the future.