### PR TITLE
Fix N5 to slice TIF conversion for incompatible types

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/N5ToSliceTiffSpark.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/N5ToSliceTiffSpark.java
@@ -292,13 +292,11 @@ public class N5ToSliceTiffSpark
 	private static < T extends NativeType< T > & RealType< T >, U extends NativeType< U > & RealType< U > > U getMappedImagePlusType( final T sourceType )
 	{
 		if ( sourceType instanceof DoubleType )
-		{
 			return ( U ) new FloatType();
-		}
-		else if ( sourceType instanceof IntType || sourceType instanceof UnsignedIntType || sourceType instanceof LongType || sourceType instanceof UnsignedLongType )
-		{
+		else if ( sourceType instanceof ByteType )
+			return ( U ) new UnsignedByteType();
+		else if ( sourceType instanceof ShortType || sourceType instanceof IntType || sourceType instanceof UnsignedIntType || sourceType instanceof LongType || sourceType instanceof UnsignedLongType )
 			return ( U ) new UnsignedShortType();
-		}
 
 		return ( U ) sourceType.createVariable();
 	}

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/N5ToSliceTiffSpark.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/N5ToSliceTiffSpark.java
@@ -283,6 +283,7 @@ public class N5ToSliceTiffSpark
 	 * - GRAY32 (float)
 	 *
 	 * If the input image is of different type, it needs to be mapped to one of the ImagePlus-supported types.
+	 * Make sure that all values in the given dataset can be represented as ImagePlus type.
 	 *
 	 * @param sourceType
 	 * @param <T>


### PR DESCRIPTION
`ImagePlus` supports only three types:
* GRAY8 (unsigned byte)
* GRAY16 (unsigned short)
* GRAY32 (float32)

In case the input type is not one of these, the conversion used to fail due to inability to instantiate an `ImagePlus` of the requested type. To solve this, the converter now maps other types to these supported types. It also validates if the output type can indeed store all data values and fails if it's not possible (for example, int64 needs to be saved as GRAY16).