### PR TITLE
Use python3

### DIFF
--- a/build-spark-local.py
+++ b/build-spark-local.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/build.py
+++ b/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/startup-scripts/spark-janelia/n5-connected-components.py
+++ b/startup-scripts/spark-janelia/n5-connected-components.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/startup-scripts/spark-janelia/n5-convert.py
+++ b/startup-scripts/spark-janelia/n5-convert.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/startup-scripts/spark-janelia/n5-downsample-label.py
+++ b/startup-scripts/spark-janelia/n5-downsample-label.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/startup-scripts/spark-janelia/n5-downsample-offset.py
+++ b/startup-scripts/spark-janelia/n5-downsample-offset.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/startup-scripts/spark-janelia/n5-downsample.py
+++ b/startup-scripts/spark-janelia/n5-downsample.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/startup-scripts/spark-janelia/n5-mips.py
+++ b/startup-scripts/spark-janelia/n5-mips.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/startup-scripts/spark-janelia/n5-remove.py
+++ b/startup-scripts/spark-janelia/n5-remove.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/startup-scripts/spark-janelia/n5-scale-pyramid-nonisotropic.py
+++ b/startup-scripts/spark-janelia/n5-scale-pyramid-nonisotropic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/startup-scripts/spark-janelia/n5-scale-pyramid-offset.py
+++ b/startup-scripts/spark-janelia/n5-scale-pyramid-offset.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/startup-scripts/spark-janelia/n5-scale-pyramid.py
+++ b/startup-scripts/spark-janelia/n5-scale-pyramid.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/startup-scripts/spark-janelia/n5-to-slice-tiff.py
+++ b/startup-scripts/spark-janelia/n5-to-slice-tiff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/startup-scripts/spark-janelia/slice-tiff-to-n5.py
+++ b/startup-scripts/spark-janelia/slice-tiff-to-n5.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/startup-scripts/spark-local/n5-connected-components.py
+++ b/startup-scripts/spark-local/n5-connected-components.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/startup-scripts/spark-local/n5-convert.py
+++ b/startup-scripts/spark-local/n5-convert.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/startup-scripts/spark-local/n5-downsample-label.py
+++ b/startup-scripts/spark-local/n5-downsample-label.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/startup-scripts/spark-local/n5-downsample-offset.py
+++ b/startup-scripts/spark-local/n5-downsample-offset.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/startup-scripts/spark-local/n5-downsample.py
+++ b/startup-scripts/spark-local/n5-downsample.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/startup-scripts/spark-local/n5-mips.py
+++ b/startup-scripts/spark-local/n5-mips.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/startup-scripts/spark-local/n5-remove.py
+++ b/startup-scripts/spark-local/n5-remove.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/startup-scripts/spark-local/n5-scale-pyramid-nonisotropic.py
+++ b/startup-scripts/spark-local/n5-scale-pyramid-nonisotropic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/startup-scripts/spark-local/n5-scale-pyramid-offset.py
+++ b/startup-scripts/spark-local/n5-scale-pyramid-offset.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/startup-scripts/spark-local/n5-scale-pyramid.py
+++ b/startup-scripts/spark-local/n5-scale-pyramid.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/startup-scripts/spark-local/n5-to-slice-tiff.py
+++ b/startup-scripts/spark-local/n5-to-slice-tiff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/startup-scripts/spark-local/slice-tiff-to-n5.py
+++ b/startup-scripts/spark-local/slice-tiff-to-n5.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys


### PR DESCRIPTION
Python2 is EOL and binaries called "python" are no longer included in some OSs/ containers.

Also, I've only run a couple of the scripts in here but from what I can tell, they work on python3 and not python2. In a python3 virtual environment, that's usually symlinked from `python`, but there's no reason the scripts here should need a virtual environment.