### PR TITLE
Migrate n5 4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 		<license.organizationName>Saalfeld Lab</license.organizationName>
 		<license.copyrightOwners>Igor Pisarev, Stephan Saalfeld</license.copyrightOwners>
 
-		<scijava.jvm.version>17</scijava.jvm.version>
+		<scijava.jvm.version>11</scijava.jvm.version>
 		<maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
 		<extra-enforcer-rules.version>1.9.0</extra-enforcer-rules.version>
 
@@ -105,15 +105,15 @@
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 		<args4j.version>2.33</args4j.version>
 
-		<n5.version>4.0.0-alpha-12-SNAPSHOT</n5.version>
+		<n5.version>4.0.0-alpha-12</n5.version>
 		<n5-aws-s3.version>4.4.0-alpha-9</n5-aws-s3.version>
 		<n5-blosc.version>2.0.0-alpha-4</n5-blosc.version>
 		<n5-google-cloud.version>5.2.0-alpha-7</n5-google-cloud.version>
-		<n5-hdf5.version>2.3.0-alpha-7-SNAPSHOT</n5-hdf5.version>
+		<n5-hdf5.version>2.3.0-alpha-7</n5-hdf5.version>
 		<n5-ij.version>4.5.0-alpha-8-SNAPSHOT</n5-ij.version>
-		<n5-imglib2.version>7.1.0-alpha-8-SNAPSHOT</n5-imglib2.version>
-		<n5-universe.version>2.4.0-alpha-9-SNAPSHOT</n5-universe.version>
-		<n5-zarr.version>2.0.0-alpha-8-SNAPSHOT</n5-zarr.version>
+		<n5-imglib2.version>7.1.0-alpha-8</n5-imglib2.version>
+		<n5-universe.version>2.4.0-alpha-9</n5-universe.version>
+		<n5-zarr.version>2.0.0-alpha-8</n5-zarr.version>
 		<n5-zstandard.version>2.0.0-alpha-4</n5-zstandard.version>
 
 		<bigdataviewer-core.version>10.4.14</bigdataviewer-core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>37.0.0</version>
+		<version>43.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -104,9 +104,18 @@
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 		<args4j.version>2.33</args4j.version>
-		<n5.version>3.2.0</n5.version>
-		<n5-imglib2.version>7.0.0</n5-imglib2.version>
-		<n5-ij.version>4.1.1</n5-ij.version>
+
+		<n5.version>4.0.0-alpha-12-SNAPSHOT</n5.version>
+		<n5-aws-s3.version>4.4.0-alpha-9</n5-aws-s3.version>
+		<n5-blosc.version>2.0.0-alpha-4</n5-blosc.version>
+		<n5-google-cloud.version>5.2.0-alpha-7</n5-google-cloud.version>
+		<n5-hdf5.version>2.3.0-alpha-7-SNAPSHOT</n5-hdf5.version>
+		<n5-ij.version>4.5.0-alpha-8-SNAPSHOT</n5-ij.version>
+		<n5-imglib2.version>7.1.0-alpha-8-SNAPSHOT</n5-imglib2.version>
+		<n5-universe.version>2.4.0-alpha-9-SNAPSHOT</n5-universe.version>
+		<n5-zarr.version>2.0.0-alpha-8-SNAPSHOT</n5-zarr.version>
+		<n5-zstandard.version>2.0.0-alpha-4</n5-zstandard.version>
+
 		<bigdataviewer-core.version>10.4.14</bigdataviewer-core.version>
 
         <kryo.version>4.0.2</kryo.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>43.0.0</version>
+		<version>45.0.0</version>
 		<relativePath />
 	</parent>
 
 	<groupId>org.janelia.saalfeldlab</groupId>
 	<artifactId>n5-spark</artifactId>
-	<version>4.0.1-SNAPSHOT</version>
+	<version>4.1.0-SNAPSHOT</version>
 
 	<name>N5 Spark</name>
 	<description>N5 Spark-based processing tools</description>
@@ -96,28 +96,13 @@
 		<license.organizationName>Saalfeld Lab</license.organizationName>
 		<license.copyrightOwners>Igor Pisarev, Stephan Saalfeld</license.copyrightOwners>
 
-		<scijava.jvm.version>11</scijava.jvm.version>
+		<scijava.jvm.version>17</scijava.jvm.version>
 		<maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
 		<extra-enforcer-rules.version>1.9.0</extra-enforcer-rules.version>
 
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
-		<args4j.version>2.33</args4j.version>
-
-		<n5.version>4.0.0-alpha-12</n5.version>
-		<n5-aws-s3.version>4.4.0-alpha-9</n5-aws-s3.version>
-		<n5-blosc.version>2.0.0-alpha-4</n5-blosc.version>
-		<n5-google-cloud.version>5.2.0-alpha-7</n5-google-cloud.version>
-		<n5-hdf5.version>2.3.0-alpha-7</n5-hdf5.version>
-		<n5-ij.version>4.5.0-alpha-8-SNAPSHOT</n5-ij.version>
-		<n5-imglib2.version>7.1.0-alpha-8</n5-imglib2.version>
-		<n5-universe.version>2.4.0-alpha-9</n5-universe.version>
-		<n5-zarr.version>2.0.0-alpha-8</n5-zarr.version>
-		<n5-zstandard.version>2.0.0-alpha-4</n5-zstandard.version>
-
-		<bigdataviewer-core.version>10.4.14</bigdataviewer-core.version>
-
         <kryo.version>4.0.2</kryo.version>
 		<alphanumeric-comparator.version>1.4.1</alphanumeric-comparator.version>
 		<spark.version>3.5.4</spark.version>
@@ -134,7 +119,6 @@
 		<dependency>
 			<groupId>args4j</groupId>
 			<artifactId>args4j</artifactId>
-			<version>${args4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imglib2</groupId>
@@ -155,22 +139,27 @@
 		<dependency>
 			<groupId>sc.fiji</groupId>
 			<artifactId>bigdataviewer-core</artifactId>
-			<version>${bigdataviewer-core.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5</artifactId>
-			<version>${n5.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-imglib2</artifactId>
-			<version>${n5-imglib2.version}</version>
+		</dependency>
+		<!-- pin the v3 (sharding) zarr stack, overriding the older versions pulled transitively by n5-ij -->
+		<dependency>
+			<groupId>org.janelia.saalfeldlab</groupId>
+			<artifactId>n5-zarr</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.janelia.saalfeldlab</groupId>
+			<artifactId>n5-universe</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-ij</artifactId>
-			<version>${n5-ij.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>net.imagej</groupId>

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/N5ConvertSpark.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/N5ConvertSpark.java
@@ -300,7 +300,7 @@ public class N5ConvertSpark
 			if ( overwriteExisting )
 			{
 				// Empty blocks will not be written out. Delete blocks to avoid remnant blocks if overwriting.
-				N5Utils.deleteBlock( convertedSourceInterval, n5OutputSupplier.get(), outputDatasetPath );
+				N5Utils.deleteChunk( convertedSourceInterval, n5OutputSupplier.get(), outputDatasetPath );
 			}
 
 			N5Utils.saveNonEmptyBlock(
@@ -373,7 +373,7 @@ public class N5ConvertSpark
 			if ( overwriteExisting )
 			{
 				// Empty blocks will not be written out. Delete blocks to avoid remnant blocks if overwriting.
-				N5Utils.deleteBlock( convertedSourceInterval, n5OutputSupplier.get(), outputDatasetPath );
+				N5Utils.deleteChunk( convertedSourceInterval, n5OutputSupplier.get(), outputDatasetPath );
 			}
 
 			N5Utils.saveNonEmptyBlock(

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/N5ConvertSpark.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/N5ConvertSpark.java
@@ -300,7 +300,7 @@ public class N5ConvertSpark
 			if ( overwriteExisting )
 			{
 				// Empty blocks will not be written out. Delete blocks to avoid remnant blocks if overwriting.
-				N5Utils.deleteChunk( convertedSourceInterval, n5OutputSupplier.get(), outputDatasetPath );
+				N5Utils.deleteBlock( convertedSourceInterval, n5OutputSupplier.get(), outputDatasetPath );
 			}
 
 			N5Utils.saveNonEmptyBlock(
@@ -373,7 +373,7 @@ public class N5ConvertSpark
 			if ( overwriteExisting )
 			{
 				// Empty blocks will not be written out. Delete blocks to avoid remnant blocks if overwriting.
-				N5Utils.deleteChunk( convertedSourceInterval, n5OutputSupplier.get(), outputDatasetPath );
+				N5Utils.deleteBlock( convertedSourceInterval, n5OutputSupplier.get(), outputDatasetPath );
 			}
 
 			N5Utils.saveNonEmptyBlock(

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/N5MaxIntensityProjectionSpark.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/N5MaxIntensityProjectionSpark.java
@@ -55,6 +55,7 @@ import org.apache.spark.broadcast.Broadcast;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.N5FSReader;
 import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 import org.janelia.saalfeldlab.n5.spark.supplier.N5ReaderSupplier;
 import org.janelia.saalfeldlab.n5.spark.util.CmdUtils;
 import org.janelia.saalfeldlab.n5.spark.util.N5SparkUtils;
@@ -219,7 +220,7 @@ public class N5MaxIntensityProjectionSpark {
 					new BasicNameValuePair("dataset", datasetPath),
 					new BasicNameValuePair("call", "create-max-intensity-projection")
 			).toString();
-			final CachedCellImg<T, ?> cellImg = Singleton.get(readerCacheKey, () -> N5SparkUtils.openWithLoaderCache(n5, datasetPath, new SoftRefLoaderCache<>()));
+			final CachedCellImg<T, ?> cellImg = Singleton.get(readerCacheKey, () -> (CachedCellImg<T, ?>)N5Utils.open(n5, datasetPath));
 			final long[] cellGridDimensions = cellImg.getCellGrid().getGridDimensions();
 			numCells = Intervals.numElements(cellGridDimensions);
 			type = Util.getTypeFromInterval(cellImg).createVariable();
@@ -249,7 +250,7 @@ public class N5MaxIntensityProjectionSpark {
 									new BasicNameValuePair("dataset", datasetPath),
 									new BasicNameValuePair("call", "create-max-intensity-projection")
 							).toString();
-							final CachedCellImg<T, ?> cellImg = Singleton.get(readerCacheKey, () -> N5SparkUtils.openWithLoaderCache(n5, datasetPath, new SoftRefLoaderCache<>()));
+							final CachedCellImg<T, ?> cellImg = Singleton.get(readerCacheKey, () -> (CachedCellImg<T, ?>)N5Utils.open(n5, datasetPath));
 							final RandomAccess<T> cellImgRandomAccess = cellImg.randomAccess();
 
 							final long[] cellMin = new long[dim], cellMax = new long[dim];

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/N5ToSliceTiffSpark.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/N5ToSliceTiffSpark.java
@@ -58,6 +58,7 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.N5FSReader;
 import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 import org.janelia.saalfeldlab.n5.spark.supplier.N5ReaderSupplier;
 import org.janelia.saalfeldlab.n5.spark.util.N5SparkUtils;
 import org.janelia.saalfeldlab.n5.spark.util.SliceDimension;
@@ -261,7 +262,7 @@ public class N5ToSliceTiffSpark
 						new BasicNameValuePair("dataset", datasetPath),
 						new BasicNameValuePair("call", "create-max-intensity-projection")
 				).toString();
-				final CachedCellImg<T, ?> cellImg = Singleton.get(readerCacheKey, () -> N5SparkUtils.openWithLoaderCache(n5, datasetPath, new SoftRefLoaderCache<>()));
+				final CachedCellImg<T, ?> cellImg = Singleton.get(readerCacheKey, () -> (CachedCellImg<T, ?>)N5Utils.open(n5, datasetPath));
 
 				final CellGrid cellGrid = cellImg.getCellGrid();
 				final long[] slicePos = new long[ cellImg.numDimensions() ], cellPos = new long[ cellImg.numDimensions() ];

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/SliceTiffToN5Spark.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/SliceTiffToN5Spark.java
@@ -223,7 +223,7 @@ public class SliceTiffToN5Spark
 								new BasicNameValuePair("call", "slice-tiff-to-n5-spark")
 						).toString();
 
-				final RandomAccessibleInterval< T > tmpImg = Singleton.get(tmpReaderCacheKey, () -> N5Utils.open( n5Local, tmpDataset ));
+				final RandomAccessibleInterval< T > tmpImg = Singleton.get(tmpReaderCacheKey, () -> (RandomAccessibleInterval< T > )N5Utils.open( n5Local, tmpDataset ));
 
 				final Interval interval = N5SparkUtils.toInterval( minMaxTuple );
 				final RandomAccessibleInterval< T > tmpImgCrop = Views.offsetInterval( tmpImg, interval );

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/downsample/N5DownsamplerSpark.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/downsample/N5DownsamplerSpark.java
@@ -28,7 +28,7 @@
  */
 package org.janelia.saalfeldlab.n5.spark.downsample;
 
-import bdv.export.Downsample;
+import org.janelia.saalfeldlab.n5.spark.util.Downsample;
 import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/downsample/N5DownsamplerSpark.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/downsample/N5DownsamplerSpark.java
@@ -47,6 +47,8 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.N5FSWriter;
 import org.janelia.saalfeldlab.n5.N5Writer;
+import org.janelia.saalfeldlab.n5.zarr.v3.ZarrV3DatasetAttributes;
+import org.janelia.saalfeldlab.n5.zarr.v3.ZarrV3KeyValueWriter;
 import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 import org.janelia.saalfeldlab.n5.spark.supplier.N5WriterSupplier;
 import org.janelia.saalfeldlab.n5.spark.util.CmdUtils;
@@ -176,6 +178,42 @@ public class N5DownsamplerSpark {
 			final int[] blockSize,
 			final boolean overwriteExisting) throws IOException {
 
+		downsample(
+				sparkContext,
+				n5Supplier,
+				inputDatasetPath,
+				outputDatasetPath,
+				downsamplingFactors,
+				blockSize,
+				null,
+				overwriteExisting);
+	}
+
+	/**
+	 * Downsamples the given input dataset with respect to the given downsampling factors, storing the output blocks in
+	 * shards of {@code chunksPerShard} chunks per axis. A {@code null} {@code chunksPerShard} writes an unsharded dataset
+	 * (identical to the other overloads). Sharding requires a zarr3 ({@link ZarrV3KeyValueWriter}) writer.
+	 *
+	 * @param sparkContext
+	 * @param n5Supplier
+	 * @param inputDatasetPath
+	 * @param outputDatasetPath
+	 * @param downsamplingFactors
+	 * @param blockSize
+	 * @param chunksPerShard number of chunks per shard per axis, or {@code null} for an unsharded output
+	 * @param overwriteExisting
+	 * @throws IOException
+	 */
+	public static <T extends NativeType<T> & RealType<T>> void downsample(
+			final JavaSparkContext sparkContext,
+			final N5WriterSupplier n5Supplier,
+			final String inputDatasetPath,
+			final String outputDatasetPath,
+			final int[] downsamplingFactors,
+			final int[] blockSize,
+			final int[] chunksPerShard,
+			final boolean overwriteExisting) throws IOException {
+
 		final N5Writer n5 = n5Supplier.get();
 		if (!n5.datasetExists(inputDatasetPath))
 			throw new IllegalArgumentException("Input N5 dataset " + inputDatasetPath + " does not exist");
@@ -206,13 +244,26 @@ public class N5DownsamplerSpark {
 			}
 		}
 
-		n5.createDataset(
-				outputDatasetPath,
-				outputDimensions,
-				outputBlockSize,
-				inputAttributes.getDataType(),
-				inputAttributes.getCompression()
-		);
+		if (chunksPerShard != null) {
+			if (!(n5 instanceof ZarrV3KeyValueWriter))
+				throw new IllegalArgumentException("Sharded downsampling requires a ZarrV3 writer");
+			final int[] shardSize = new int[dim];
+			for (int d = 0; d < dim; ++d)
+				shardSize[d] = chunksPerShard[d] * outputBlockSize[d];
+
+			n5.createDataset(
+					outputDatasetPath,
+					new ZarrV3DatasetAttributes(outputDimensions, shardSize, outputBlockSize, inputAttributes.getDataType(), inputAttributes.getCompression())
+			);
+		} else {
+			n5.createDataset(
+					outputDatasetPath,
+					outputDimensions,
+					outputBlockSize,
+					inputAttributes.getDataType(),
+					inputAttributes.getCompression()
+			);
+		}
 
 		// set the downsampling factors attribute
 		final int[] inputAbsoluteDownsamplingFactors = n5.getAttribute(inputDatasetPath, DOWNSAMPLING_FACTORS_ATTRIBUTE_KEY, int[].class);
@@ -221,14 +272,17 @@ public class N5DownsamplerSpark {
 			outputAbsoluteDownsamplingFactors[d] = downsamplingFactors[d] * (inputAbsoluteDownsamplingFactors != null ? inputAbsoluteDownsamplingFactors[d] : 1);
 		n5.setAttribute(outputDatasetPath, DOWNSAMPLING_FACTORS_ATTRIBUTE_KEY, outputAbsoluteDownsamplingFactors);
 
-		final CellGrid outputCellGrid = new CellGrid(outputDimensions, outputBlockSize);
+		/* the parallel-write unit is DatasetAttributes#getBlockSize: the shard for a sharded dataset, the chunk otherwise */
+		final int[] writeBlockSize = n5.getDatasetAttributes(outputDatasetPath).getBlockSize();
+
+		final CellGrid outputCellGrid = new CellGrid(outputDimensions, writeBlockSize);
 		final long numDownsampledBlocks = Intervals.numElements(outputCellGrid.getGridDimensions());
 		final List<Long> blockIndexes = LongStream.range(0, numDownsampledBlocks).boxed().collect(Collectors.toList());
 
 		sparkContext
 				.parallelize(blockIndexes, Math.min(blockIndexes.size(), MAX_PARTITIONS))
 				.foreach(blockIndex -> {
-					final CellGrid cellGrid = new CellGrid(outputDimensions, outputBlockSize);
+					final CellGrid cellGrid = new CellGrid(outputDimensions, writeBlockSize);
 					final long[] blockGridPosition = new long[cellGrid.numDimensions()];
 					cellGrid.getCellGridPositionFlat(blockIndex, blockGridPosition);
 
@@ -279,12 +333,19 @@ public class N5DownsamplerSpark {
 					final RandomAccessibleInterval<T> targetBlock = new ArrayImgFactory<>(defaultValue).create(targetInterval);
 					Downsample.downsample(sourceBlock, targetBlock, downsamplingFactors);
 
+					final DatasetAttributes outputAttributes = n5Writer.getDatasetAttributes(outputDatasetPath);
+					final int[] shardBlockSize = outputAttributes.getBlockSize();
+					final int[] innerChunkSize = outputAttributes.getChunkSize();
+					final long[] chunkGridOffset = new long[dim];
+					for (int d = 0; d < dim; ++d)
+						chunkGridOffset[d] = blockGridPosition[d] * (shardBlockSize[d] / innerChunkSize[d]);
+
 					if (overwriteExisting) {
 						// Empty blocks will not be written out. Delete blocks to avoid remnant blocks if overwriting.
-						N5Utils.deleteBlock(targetBlock, n5Writer, outputDatasetPath, blockGridPosition);
+						N5Utils.deleteBlock(targetBlock, n5Writer, outputDatasetPath, chunkGridOffset);
 					}
 
-					N5Utils.saveNonEmptyBlock(targetBlock, n5Writer, outputDatasetPath, blockGridPosition, defaultValue);
+					N5Utils.saveNonEmptyBlock(targetBlock, n5Writer, outputDatasetPath, outputAttributes, chunkGridOffset, defaultValue);
 				});
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/downsample/N5DownsamplerSpark.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/downsample/N5DownsamplerSpark.java
@@ -281,7 +281,7 @@ public class N5DownsamplerSpark {
 
 					if (overwriteExisting) {
 						// Empty blocks will not be written out. Delete blocks to avoid remnant blocks if overwriting.
-						N5Utils.deleteChunk(targetBlock, n5Writer, outputDatasetPath, blockGridPosition);
+						N5Utils.deleteBlock(targetBlock, n5Writer, outputDatasetPath, blockGridPosition);
 					}
 
 					N5Utils.saveNonEmptyBlock(targetBlock, n5Writer, outputDatasetPath, blockGridPosition, defaultValue);

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/downsample/N5DownsamplerSpark.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/downsample/N5DownsamplerSpark.java
@@ -261,7 +261,7 @@ public class N5DownsamplerSpark {
 									new BasicNameValuePair("call", "n5-downsample-spark")
 							).toString();
 
-					final RandomAccessibleInterval< T > source = Singleton.get(imgCacheKey, () -> N5Utils.open( n5Writer, inputDatasetPath ));
+					final RandomAccessibleInterval< T > source = Singleton.get(imgCacheKey, () -> (RandomAccessibleInterval< T > )N5Utils.open( n5Writer, inputDatasetPath ));
 					final RandomAccessibleInterval<T> sourceBlock = Views.offsetInterval(source, sourceInterval);
 
 					/* test if empty */
@@ -281,7 +281,7 @@ public class N5DownsamplerSpark {
 
 					if (overwriteExisting) {
 						// Empty blocks will not be written out. Delete blocks to avoid remnant blocks if overwriting.
-						N5Utils.deleteBlock(targetBlock, n5Writer, outputDatasetPath, blockGridPosition);
+						N5Utils.deleteChunk(targetBlock, n5Writer, outputDatasetPath, blockGridPosition);
 					}
 
 					N5Utils.saveNonEmptyBlock(targetBlock, n5Writer, outputDatasetPath, blockGridPosition, defaultValue);

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/downsample/N5LabelDownsamplerSpark.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/downsample/N5LabelDownsamplerSpark.java
@@ -255,7 +255,7 @@ public class N5LabelDownsamplerSpark {
 
 					if (overwriteExisting) {
 						// Empty blocks will not be written out. Delete blocks to avoid remnant blocks if overwriting.
-						N5Utils.deleteChunk(targetBlock, n5Writer, outputDatasetPath, blockGridPosition);
+						N5Utils.deleteBlock(targetBlock, n5Writer, outputDatasetPath, blockGridPosition);
 					}
 
 					N5Utils.saveNonEmptyBlock(targetBlock, n5Writer, outputDatasetPath, blockGridPosition, defaultValue);

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/downsample/N5LabelDownsamplerSpark.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/downsample/N5LabelDownsamplerSpark.java
@@ -52,10 +52,13 @@ import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.N5FSWriter;
+import org.janelia.saalfeldlab.n5.zarr.v3.ZarrV3DatasetAttributes;
+import org.janelia.saalfeldlab.n5.zarr.v3.ZarrV3KeyValueWriter;
 import org.janelia.saalfeldlab.n5.N5Writer;
 import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 import org.janelia.saalfeldlab.n5.spark.supplier.N5WriterSupplier;
 import org.janelia.saalfeldlab.n5.spark.util.CmdUtils;
+import org.janelia.scicomp.n5.zstandard.ZstandardCompression;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
@@ -159,6 +162,43 @@ public class N5LabelDownsamplerSpark {
 			final int[] blockSize,
 			final boolean overwriteExisting) throws IOException {
 
+		downsampleLabel(
+				sparkContext,
+				n5Supplier,
+				inputDatasetPath,
+				outputDatasetPath,
+				downsamplingFactors,
+				blockSize,
+				null,
+				overwriteExisting
+		);
+	}
+
+	/**
+	 * Downsamples the given input dataset with respect to the given downsampling factors, storing the output blocks
+	 * in shards of {@code chunksPerShard} chunks per axis. A {@code null} {@code chunksPerShard} writes an unsharded
+	 * dataset (identical to the other overloads). Sharding requires a zarr3 ({@link ZarrV3KeyValueWriter}) writer.
+	 *
+	 * @param sparkContext
+	 * @param n5Supplier
+	 * @param inputDatasetPath
+	 * @param outputDatasetPath
+	 * @param downsamplingFactors
+	 * @param blockSize
+	 * @param chunksPerShard number of chunks per shard per axis, or {@code null} for an unsharded output
+	 * @param overwriteExisting
+	 * @throws IOException
+	 */
+	public static <T extends NativeType<T> & IntegerType<T>> void downsampleLabel(
+			final JavaSparkContext sparkContext,
+			final N5WriterSupplier n5Supplier,
+			final String inputDatasetPath,
+			final String outputDatasetPath,
+			final int[] downsamplingFactors,
+			final int[] blockSize,
+			final int[] chunksPerShard,
+			final boolean overwriteExisting) throws IOException {
+
 		final N5Writer n5 = n5Supplier.get();
 		if (!n5.datasetExists(inputDatasetPath))
 			throw new IllegalArgumentException("Input N5 dataset " + inputDatasetPath + " does not exist");
@@ -189,22 +229,38 @@ public class N5LabelDownsamplerSpark {
 			}
 		}
 
-		n5.createDataset(
-				outputDatasetPath,
-				outputDimensions,
-				outputBlockSize,
-				inputAttributes.getDataType(),
-				inputAttributes.getCompression()
-		);
+		if (chunksPerShard != null) {
+			if (!(n5 instanceof ZarrV3KeyValueWriter))
+				throw new IllegalArgumentException("Sharded downsampling requires a ZarrV3 writer");
+			final int[] shardSize = new int[dim];
+			for (int d = 0; d < dim; ++d)
+				shardSize[d] = chunksPerShard[d] * outputBlockSize[d];
 
-		final CellGrid outputCellGrid = new CellGrid(outputDimensions, outputBlockSize);
+			n5.createDataset(
+					outputDatasetPath,
+					new ZarrV3DatasetAttributes(outputDimensions, shardSize, outputBlockSize, inputAttributes.getDataType(), new ZstandardCompression())
+			);
+		} else {
+			n5.createDataset(
+					outputDatasetPath,
+					outputDimensions,
+					outputBlockSize,
+					inputAttributes.getDataType(),
+					new ZstandardCompression()
+			);
+		}
+
+		/* the parallel-write unit is DatasetAttributes#getBlockSize: the shard for a sharded dataset, the chunk otherwise */
+		final int[] writeBlockSize = n5.getDatasetAttributes(outputDatasetPath).getBlockSize();
+
+		final CellGrid outputCellGrid = new CellGrid(outputDimensions, writeBlockSize);
 		final long numDownsampledBlocks = Intervals.numElements(outputCellGrid.getGridDimensions());
 		final List<Long> blockIndexes = LongStream.range(0, numDownsampledBlocks).boxed().collect(Collectors.toList());
 
 		sparkContext
 				.parallelize(blockIndexes, Math.min(blockIndexes.size(), MAX_PARTITIONS))
 				.foreach(blockIndex -> {
-					final CellGrid cellGrid = new CellGrid(outputDimensions, outputBlockSize);
+					final CellGrid cellGrid = new CellGrid(outputDimensions, writeBlockSize);
 					final long[] blockGridPosition = new long[cellGrid.numDimensions()];
 					cellGrid.getCellGridPositionFlat(blockIndex, blockGridPosition);
 
@@ -253,17 +309,23 @@ public class N5LabelDownsamplerSpark {
 					final RandomAccessibleInterval<T> targetBlock = new ArrayImgFactory<>(defaultValue).create(targetInterval);
 					downsampleLabel(sourceBlock, targetBlock, downsamplingFactors);
 
+					final DatasetAttributes outputAttributes = n5Writer.getDatasetAttributes(outputDatasetPath);
+					final int[] shardBlockSize = outputAttributes.getBlockSize();
+					final int[] innerChunkSize = outputAttributes.getChunkSize();
+					final long[] chunkGridOffset = new long[dim];
+					for (int d = 0; d < dim; ++d)
+						chunkGridOffset[d] = blockGridPosition[d] * (shardBlockSize[d] / innerChunkSize[d]);
+
 					if (overwriteExisting) {
 						// Empty blocks will not be written out. Delete blocks to avoid remnant blocks if overwriting.
-						N5Utils.deleteBlock(targetBlock, n5Writer, outputDatasetPath, blockGridPosition);
+						N5Utils.deleteBlock(targetBlock, n5Writer, outputDatasetPath, chunkGridOffset);
 					}
-
-					N5Utils.saveNonEmptyBlock(targetBlock, n5Writer, outputDatasetPath, blockGridPosition, defaultValue);
+					N5Utils.saveNonEmptyBlock(targetBlock, n5Writer, outputDatasetPath, outputAttributes, chunkGridOffset, defaultValue);
 				});
 	}
 
 	/**
-	 * Based on {@link bdv.export.Downsample}.
+	 * Based on bdv.export.Downsample.
 	 */
 	private static <T extends IntegerType<T>> void downsampleLabel(
 			final RandomAccessible<T> input,

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/downsample/N5LabelDownsamplerSpark.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/downsample/N5LabelDownsamplerSpark.java
@@ -235,7 +235,7 @@ public class N5LabelDownsamplerSpark {
 									new BasicNameValuePair("call", "n5-downsample-spark")
 							).toString();
 
-					final RandomAccessibleInterval< T > source = Singleton.get(imgCacheKey, () -> N5Utils.open( n5Writer, inputDatasetPath ));
+					final RandomAccessibleInterval< T > source = Singleton.get(imgCacheKey, () -> (RandomAccessibleInterval< T >)N5Utils.open( n5Writer, inputDatasetPath ));
 					final RandomAccessibleInterval<T> sourceBlock = Views.offsetInterval(source, sourceInterval);
 
 					/* test if empty */
@@ -255,7 +255,7 @@ public class N5LabelDownsamplerSpark {
 
 					if (overwriteExisting) {
 						// Empty blocks will not be written out. Delete blocks to avoid remnant blocks if overwriting.
-						N5Utils.deleteBlock(targetBlock, n5Writer, outputDatasetPath, blockGridPosition);
+						N5Utils.deleteChunk(targetBlock, n5Writer, outputDatasetPath, blockGridPosition);
 					}
 
 					N5Utils.saveNonEmptyBlock(targetBlock, n5Writer, outputDatasetPath, blockGridPosition, defaultValue);

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/downsample/N5OffsetDownsamplerSpark.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/downsample/N5OffsetDownsamplerSpark.java
@@ -50,7 +50,7 @@ import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 
-import bdv.export.Downsample;
+import org.janelia.saalfeldlab.n5.spark.util.Downsample;
 import net.imglib2.Cursor;
 import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
@@ -242,7 +242,7 @@ public class N5OffsetDownsamplerSpark
 	}
 
 	/**
-	 * Based on {@link bdv.export.Downsample}.
+	 * Based on {@link Downsample}.
 	 */
 	private static < T extends RealType< T > > void downsampleIntervalOutOfBoundsCheck(
 			final RandomAccessible< T > input,

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/downsample/N5OffsetDownsamplerSpark.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/downsample/N5OffsetDownsamplerSpark.java
@@ -202,7 +202,7 @@ public class N5OffsetDownsamplerSpark
 							new BasicNameValuePair("call", "n5-downsample-spark")
 					).toString();
 
-			final RandomAccessibleInterval< T > source = Singleton.get(imgCacheKey, () -> N5Utils.open( n5Writer, inputDatasetPath ));
+			final RandomAccessibleInterval< T > source = Singleton.get(imgCacheKey, () -> (RandomAccessibleInterval< T >)N5Utils.open( n5Writer, inputDatasetPath ));
 
 			// apply offset to source to align it with respect to the target block
 			final RandomAccessibleInterval< T > translatedSource = Views.translate( source, offset );

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/downsample/N5OffsetDownsamplerSpark.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/downsample/N5OffsetDownsamplerSpark.java
@@ -43,6 +43,8 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.N5FSWriter;
 import org.janelia.saalfeldlab.n5.N5Writer;
+import org.janelia.saalfeldlab.n5.zarr.v3.ZarrV3DatasetAttributes;
+import org.janelia.saalfeldlab.n5.zarr.v3.ZarrV3KeyValueWriter;
 import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 import org.janelia.saalfeldlab.n5.spark.supplier.N5WriterSupplier;
 import org.janelia.saalfeldlab.n5.spark.util.CmdUtils;
@@ -134,6 +136,43 @@ public class N5OffsetDownsamplerSpark
 			final long[] offset,
 			final int[] blockSize ) throws IOException
 	{
+		downsampleWithOffset(
+				sparkContext,
+				n5Supplier,
+				inputDatasetPath,
+				outputDatasetPath,
+				downsamplingFactors,
+				offset,
+				blockSize,
+				null
+			);
+	}
+
+	/**
+	 * Downsamples the given input dataset with respect to the given downsampling factors and offset, storing the output
+	 * blocks in shards of {@code chunksPerShard} chunks per axis. A {@code null} {@code chunksPerShard} writes an
+	 * unsharded dataset (identical to the other overloads). Sharding requires a zarr3 ({@link ZarrV3KeyValueWriter}) writer.
+	 *
+	 * @param sparkContext
+	 * @param n5Supplier
+	 * @param inputDatasetPath
+	 * @param outputDatasetPath
+	 * @param downsamplingFactors
+	 * @param offset
+	 * @param blockSize
+	 * @param chunksPerShard number of chunks per shard per axis, or {@code null} for an unsharded output
+	 * @throws IOException
+	 */
+	public static < T extends NativeType< T > & RealType< T > > void downsampleWithOffset(
+			final JavaSparkContext sparkContext,
+			final N5WriterSupplier n5Supplier,
+			final String inputDatasetPath,
+			final String outputDatasetPath,
+			final int[] downsamplingFactors,
+			final long[] offset,
+			final int[] blockSize,
+			final int[] chunksPerShard ) throws IOException
+	{
 		final N5Writer n5 = n5Supplier.get();
 		if ( !n5.datasetExists( inputDatasetPath ) )
 			throw new IllegalArgumentException( "Input N5 dataset " + inputDatasetPath + " does not exist" );
@@ -154,22 +193,42 @@ public class N5OffsetDownsamplerSpark
 			throw new IllegalArgumentException( "Degenerate output dimensions: " + Arrays.toString( outputDimensions ) );
 
 		final int[] outputBlockSize = blockSize != null ? blockSize : inputAttributes.getBlockSize();
-		n5.createDataset(
-				outputDatasetPath,
-				outputDimensions,
-				outputBlockSize,
-				inputAttributes.getDataType(),
-				inputAttributes.getCompression()
-			);
 
-		final CellGrid outputCellGrid = new CellGrid( outputDimensions, outputBlockSize );
+		if ( chunksPerShard != null )
+		{
+			if ( !( n5 instanceof ZarrV3KeyValueWriter ) )
+				throw new IllegalArgumentException( "Sharded downsampling requires a ZarrV3 writer" );
+			final int[] shardSize = new int[ dim ];
+			for ( int d = 0; d < dim; ++d )
+				shardSize[ d ] = chunksPerShard[ d ] * outputBlockSize[ d ];
+
+			n5.createDataset(
+					outputDatasetPath,
+					new ZarrV3DatasetAttributes( outputDimensions, shardSize, outputBlockSize, inputAttributes.getDataType(), inputAttributes.getCompression() )
+				);
+		}
+		else
+		{
+			n5.createDataset(
+					outputDatasetPath,
+					outputDimensions,
+					outputBlockSize,
+					inputAttributes.getDataType(),
+					inputAttributes.getCompression()
+				);
+		}
+
+		/* the parallel-write unit is DatasetAttributes#getBlockSize: the shard for a sharded dataset, the chunk otherwise */
+		final int[] writeBlockSize = n5.getDatasetAttributes( outputDatasetPath ).getBlockSize();
+
+		final CellGrid outputCellGrid = new CellGrid( outputDimensions, writeBlockSize );
 		final long numDownsampledBlocks = Intervals.numElements( outputCellGrid.getGridDimensions() );
 		final List< Long > blockIndexes = LongStream.range( 0, numDownsampledBlocks ).boxed().collect( Collectors.toList() );
 
 		sparkContext.parallelize( blockIndexes, Math.min( blockIndexes.size(), MAX_PARTITIONS ) ).foreach( blockIndex ->
 		{
 			// downsampled block index to grid position
-			final CellGrid cellGrid = new CellGrid( outputDimensions, outputBlockSize );
+			final CellGrid cellGrid = new CellGrid( outputDimensions, writeBlockSize );
 			final long[] blockGridPosition = new long[ cellGrid.numDimensions() ];
 			cellGrid.getCellGridPositionFlat( blockIndex, blockGridPosition );
 
@@ -237,7 +296,14 @@ public class N5OffsetDownsamplerSpark
 			else
 				downsampleIntervalOutOfBoundsCheck( sourceBlock, targetBlock, downsamplingFactors, definedSourceBlockInterval );
 
-			N5Utils.saveNonEmptyBlock( targetBlock, n5Writer, outputDatasetPath, blockGridPosition, defaultValue );
+			final DatasetAttributes outputAttributes = n5Writer.getDatasetAttributes( outputDatasetPath );
+			final int[] shardBlockSize = outputAttributes.getBlockSize();
+			final int[] innerChunkSize = outputAttributes.getChunkSize();
+			final long[] chunkGridOffset = new long[ dim ];
+			for ( int d = 0; d < dim; ++d )
+				chunkGridOffset[ d ] = blockGridPosition[ d ] * ( shardBlockSize[ d ] / innerChunkSize[ d ] );
+
+			N5Utils.saveNonEmptyBlock( targetBlock, n5Writer, outputDatasetPath, outputAttributes, chunkGridOffset, defaultValue );
 		} );
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/util/Downsample.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/util/Downsample.java
@@ -1,0 +1,97 @@
+/*
+ * Copied from bdv.export.Downsample (bigdataviewer-core), since it was removed in
+ * bigdataviewer-core 10.5.0.
+ * Original license below.
+ *
+ * #%L
+ * BigDataViewer core classes with minimal dependencies.
+ * %%
+ * Copyright (C) 2012 - 2024 BigDataViewer developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.janelia.saalfeldlab.n5.spark.util;
+
+import net.imglib2.Cursor;
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.neighborhood.Neighborhood;
+import net.imglib2.algorithm.neighborhood.RectangleNeighborhoodFactory;
+import net.imglib2.algorithm.neighborhood.RectangleNeighborhoodUnsafe;
+import net.imglib2.algorithm.neighborhood.RectangleShape;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.view.Views;
+
+public class Downsample
+{
+	/**
+	 * TODO: Revise. This is probably not very efficient
+	 */
+	public static < T extends RealType< T > > void downsample( final RandomAccessible< T > input, final RandomAccessibleInterval< T > output, final int[] factor )
+	{
+		assert input.numDimensions() == output.numDimensions();
+		assert input.numDimensions() == factor.length;
+
+		final int n = input.numDimensions();
+		final RectangleNeighborhoodFactory< T > f = RectangleNeighborhoodUnsafe.< T >factory();
+		final long[] dim = new long[ n ];
+		for ( int d = 0; d < n; ++d )
+			dim[ d ] = factor[ d ];
+		final Interval spanInterval = new FinalInterval( dim );
+
+		final long[] minRequiredInput = new long[ n ];
+		final long[] maxRequiredInput = new long[ n ];
+		output.min( minRequiredInput );
+		output.max( maxRequiredInput );
+		for ( int d = 0; d < n; ++d )
+		{
+			minRequiredInput[ d ] *= factor[ d ];
+			maxRequiredInput[ d ] *= factor[ d ];
+			maxRequiredInput[ d ] += factor[ d ] - 1;
+		}
+		final RandomAccessibleInterval< T > requiredInput = Views.interval( input, new FinalInterval( minRequiredInput, maxRequiredInput ) );
+
+		final RectangleShape.NeighborhoodsAccessible< T > neighborhoods = new RectangleShape.NeighborhoodsAccessible<>( requiredInput, spanInterval, f );
+		final RandomAccess< Neighborhood< T > > block = neighborhoods.randomAccess();
+
+		long size = 1;
+		for ( int d = 0; d < n; ++d )
+			size *= factor[ d ];
+		final double scale = 1.0 / size;
+
+		final Cursor< T > out = Views.iterable( output ).localizingCursor();
+		while( out.hasNext() )
+		{
+			final T o = out.next();
+			for ( int d = 0; d < n; ++d )
+				block.setPosition( out.getLongPosition( d ) * factor[ d ], d );
+			double sum = 0;
+			for ( final T i : block.get() )
+				sum += i.getRealDouble();
+			o.setReal( sum * scale );
+		}
+	}
+}

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/util/N5SparkUtils.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/util/N5SparkUtils.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -28,24 +28,21 @@
  */
 package org.janelia.saalfeldlab.n5.spark.util;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
 import net.imglib2.util.Intervals;
 import scala.Tuple2;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class N5SparkUtils
 {
 	private N5SparkUtils() { }
 
-	public static List< Tuple2< long[], long[] > > toMinMaxTuples( final List< ? extends Interval > intervals )
+	public static List< Tuple2< long[], long[] > > toMinMaxTuples(final List< ? extends Interval > intervals )
 	{
-		return new ArrayList<>(
-				intervals.stream().map( N5SparkUtils::toMinMaxTuple ).collect( Collectors.toList() )
-			);
+		return intervals.stream().map(N5SparkUtils::toMinMaxTuple).collect(Collectors.toList());
 	}
 
 	public static Tuple2< long[], long[] > toMinMaxTuple( final Interval interval )

--- a/src/main/java/org/janelia/saalfeldlab/n5/spark/util/N5SparkUtils.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/spark/util/N5SparkUtils.java
@@ -28,41 +28,12 @@
  */
 package org.janelia.saalfeldlab.n5.spark.util;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
-
-import org.janelia.saalfeldlab.n5.DatasetAttributes;
-import org.janelia.saalfeldlab.n5.N5Reader;
-import org.janelia.saalfeldlab.n5.imglib2.N5CellLoader;
 
 import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
-import net.imglib2.cache.Cache;
-import net.imglib2.cache.CacheLoader;
-import net.imglib2.cache.LoaderCache;
-import net.imglib2.cache.img.CachedCellImg;
-import net.imglib2.cache.img.LoadedCellCacheLoader;
-import net.imglib2.cache.ref.BoundedSoftRefLoaderCache;
-import net.imglib2.img.basictypeaccess.AccessFlags;
-import net.imglib2.img.basictypeaccess.ArrayDataAccessFactory;
-import net.imglib2.img.cell.Cell;
-import net.imglib2.img.cell.CellGrid;
-import net.imglib2.img.cell.LazyCellImg;
-import net.imglib2.type.NativeType;
-import net.imglib2.type.PrimitiveType;
-import net.imglib2.type.numeric.integer.ByteType;
-import net.imglib2.type.numeric.integer.IntType;
-import net.imglib2.type.numeric.integer.LongType;
-import net.imglib2.type.numeric.integer.ShortType;
-import net.imglib2.type.numeric.integer.UnsignedByteType;
-import net.imglib2.type.numeric.integer.UnsignedIntType;
-import net.imglib2.type.numeric.integer.UnsignedLongType;
-import net.imglib2.type.numeric.integer.UnsignedShortType;
-import net.imglib2.type.numeric.real.DoubleType;
-import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.util.Intervals;
 import scala.Tuple2;
 
@@ -93,98 +64,4 @@ public class N5SparkUtils
 			);
 	}
 
-	/**
-	 * Open an N5 dataset as a memory cached {@link LazyCellImg} with bounded cache size.
-	 *
-	 * @param n5
-	 * @param dataset
-	 * @param cacheSize
-	 * @return
-	 * @throws IOException
-	 */
-	@SuppressWarnings( { "unchecked", "rawtypes" } )
-	public static final < T extends NativeType< T > > CachedCellImg< T, ? > openWithBoundedCache(
-			final N5Reader n5,
-			final String dataset,
-			final int cacheSize ) throws IOException
-	{
-		return openWithLoaderCache( n5, dataset, new BoundedSoftRefLoaderCache<>(cacheSize));
-	}
-
-	public static final < T extends NativeType< T > > CachedCellImg< T, ? > openWithLoaderCache(
-			final N5Reader n5,
-			final String dataset,
-			final LoaderCache<Long, Cell<?>> loaderCache) throws IOException
-	{
-		final DatasetAttributes attributes = n5.getDatasetAttributes( dataset );
-		final long[] dimensions = attributes.getDimensions();
-		final int[] blockSize = attributes.getBlockSize();
-
-		final N5CellLoader< T > loader = new N5CellLoader<>( n5, dataset, blockSize );
-
-		final CellGrid grid = new CellGrid( dimensions, blockSize );
-
-		final CachedCellImg< T, ? > img;
-		final T type;
-		final Cache< Long, Cell< ? > > cache;
-		final Set< AccessFlags > accessFlags = AccessFlags.setOf();
-
-		switch ( attributes.getDataType() )
-		{
-		case INT8:
-			type = ( T )new ByteType();
-			cache = loaderCache.withLoader( ( CacheLoader )LoadedCellCacheLoader.get( grid, loader, type, accessFlags ) );
-			img = new CachedCellImg( grid, type, cache, ArrayDataAccessFactory.get( PrimitiveType.BYTE, accessFlags ) );
-			break;
-		case UINT8:
-			type = ( T )new UnsignedByteType();
-			cache = loaderCache.withLoader( ( CacheLoader )LoadedCellCacheLoader.get( grid, loader, type, accessFlags ) );
-			img = new CachedCellImg( grid, type, cache, ArrayDataAccessFactory.get( PrimitiveType.BYTE, accessFlags ) );
-			break;
-		case INT16:
-			type = ( T )new ShortType();
-			cache = loaderCache.withLoader( ( CacheLoader )LoadedCellCacheLoader.get( grid, loader, type, accessFlags ) );
-			img = new CachedCellImg( grid, type, cache, ArrayDataAccessFactory.get( PrimitiveType.SHORT, accessFlags ) );
-			break;
-		case UINT16:
-			type = ( T )new UnsignedShortType();
-			cache = loaderCache.withLoader( ( CacheLoader )LoadedCellCacheLoader.get( grid, loader, type, accessFlags ) );
-			img = new CachedCellImg( grid, type, cache, ArrayDataAccessFactory.get( PrimitiveType.SHORT, accessFlags ) );
-			break;
-		case INT32:
-			type = ( T )new IntType();
-			cache = loaderCache.withLoader( ( CacheLoader )LoadedCellCacheLoader.get( grid, loader, type, accessFlags ) );
-			img = new CachedCellImg( grid, type, cache, ArrayDataAccessFactory.get( PrimitiveType.INT, accessFlags ) );
-			break;
-		case UINT32:
-			type = ( T )new UnsignedIntType();
-			cache = loaderCache.withLoader( ( CacheLoader )LoadedCellCacheLoader.get( grid, loader, type, accessFlags ) );
-			img = new CachedCellImg( grid, type, cache, ArrayDataAccessFactory.get( PrimitiveType.INT, accessFlags ) );
-			break;
-		case INT64:
-			type = ( T )new LongType();
-			cache = loaderCache.withLoader( ( CacheLoader )LoadedCellCacheLoader.get( grid, loader, type, accessFlags ) );
-			img = new CachedCellImg( grid, type, cache, ArrayDataAccessFactory.get( PrimitiveType.LONG, accessFlags ) );
-			break;
-		case UINT64:
-			type = ( T )new UnsignedLongType();
-			cache = loaderCache.withLoader( ( CacheLoader )LoadedCellCacheLoader.get( grid, loader, type, accessFlags ) );
-			img = new CachedCellImg( grid, type, cache, ArrayDataAccessFactory.get( PrimitiveType.LONG, accessFlags ) );
-			break;
-		case FLOAT32:
-			type = ( T )new FloatType();
-			cache = loaderCache.withLoader( ( CacheLoader )LoadedCellCacheLoader.get( grid, loader, type, accessFlags ) );
-			img = new CachedCellImg( grid, type, cache, ArrayDataAccessFactory.get( PrimitiveType.FLOAT, accessFlags ) );
-			break;
-		case FLOAT64:
-			type = ( T )new DoubleType();
-			cache = loaderCache.withLoader( ( CacheLoader )LoadedCellCacheLoader.get( grid, loader, type, accessFlags ) );
-			img = new CachedCellImg( grid, type, cache, ArrayDataAccessFactory.get( PrimitiveType.DOUBLE, accessFlags ) );
-			break;
-		default:
-			img = null;
-		}
-
-		return img;
-	}
 }

--- a/src/test/java/org/janelia/saalfeldlab/n5/spark/downsample/N5DownsamplerSparkTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/spark/downsample/N5DownsamplerSparkTest.java
@@ -41,6 +41,10 @@ import org.janelia.saalfeldlab.n5.N5FSWriter;
 import org.janelia.saalfeldlab.n5.N5Writer;
 import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 import org.janelia.saalfeldlab.n5.spark.AbstractN5SparkTest;
+import org.janelia.saalfeldlab.n5.spark.supplier.N5WriterSupplier;
+import org.janelia.saalfeldlab.n5.universe.N5Factory;
+import org.janelia.saalfeldlab.n5.universe.StorageFormat;
+import org.janelia.scicomp.n5.zstandard.ZstandardCompression;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -166,6 +170,47 @@ public class N5DownsamplerSparkTest extends AbstractN5SparkTest
 		Assert.assertArrayEquals( new int[] { ( int ) Util.round( sum * scale ) }, getArrayFromRandomAccessibleInterval( N5Utils.open( n5, downsampledDatasetPath ) ) );
 	}
 
+
+	@Test
+	public void testShardedDownsampling() throws IOException
+	{
+		final String zarr3Path = basePath + ".zarr";
+		final N5WriterSupplier zarr3Supplier = () -> new N5Factory().openWriter( StorageFormat.ZARR3, zarr3Path );
+
+		final long[] dimensions = { 32, 32, 32 };
+		final int[] blockSize = { 8, 8, 8 };
+		final int[] downsamplingFactors = { 2, 2, 2 };
+		final int[] chunksPerShard = { 2, 2, 2 };
+
+		final N5Writer n5 = zarr3Supplier.get();
+		final int[] data = new int[ ( int ) Intervals.numElements( dimensions ) ];
+		for ( int i = 0; i < data.length; ++i )
+			data[ i ] = i + 1;
+		N5Utils.save( ArrayImgs.ints( data, dimensions ), n5, datasetPath, blockSize, new ZstandardCompression() );
+
+		/* downsample the same data, both unsharded and sharded, to compare later */
+		N5DownsamplerSpark.downsample( sparkContext, zarr3Supplier, datasetPath, "downsampled-unsharded", downsamplingFactors, blockSize, null, false );
+		N5DownsamplerSpark.downsample( sparkContext, zarr3Supplier, datasetPath, "downsampled-sharded", downsamplingFactors, blockSize, chunksPerShard, false );
+
+		final long[] expectedOutputDimensions = new long[ dimensions.length ];
+		final int[] expectedShardSize = new int[ blockSize.length ];
+		for ( int d = 0; d < dimensions.length; ++d )
+		{
+			expectedOutputDimensions[ d ] = dimensions[ d ] / downsamplingFactors[ d ];
+			expectedShardSize[ d ] = chunksPerShard[ d ] * blockSize[ d ];
+		}
+
+		final DatasetAttributes shardedAttributes = n5.getDatasetAttributes( "downsampled-sharded" );
+		Assert.assertArrayEquals( expectedOutputDimensions, shardedAttributes.getDimensions() );
+		Assert.assertArrayEquals( blockSize, shardedAttributes.getChunkSize() );          // inner chunk
+		Assert.assertArrayEquals( expectedShardSize, shardedAttributes.getBlockSize() );  // shard = chunksPerShard * chunk
+
+		/* the sharded output should be identical to the unsharded output */
+		Assert.assertArrayEquals(
+				getArrayFromRandomAccessibleInterval( N5Utils.open( n5, "downsampled-unsharded" ) ),
+				getArrayFromRandomAccessibleInterval( N5Utils.open( n5, "downsampled-sharded" ) )
+			);
+	}
 
 	private void createDataset( final N5Writer n5, final long[] dimensions, final int[] blockSize ) throws IOException
 	{

--- a/src/test/java/org/janelia/saalfeldlab/n5/spark/downsample/N5OffsetDownsamplerSparkTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/spark/downsample/N5OffsetDownsamplerSparkTest.java
@@ -41,6 +41,9 @@ import org.janelia.saalfeldlab.n5.N5FSWriter;
 import org.janelia.saalfeldlab.n5.N5Writer;
 import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 import org.janelia.saalfeldlab.n5.spark.AbstractN5SparkTest;
+import org.janelia.saalfeldlab.n5.spark.supplier.N5WriterSupplier;
+import org.janelia.saalfeldlab.n5.universe.N5Factory;
+import org.janelia.saalfeldlab.n5.universe.StorageFormat;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -155,6 +158,44 @@ public class N5OffsetDownsamplerSparkTest extends AbstractN5SparkTest
 		}
 	}
 
+
+	@Test
+	public void testShardedDownsamplingWithOffset() throws IOException
+	{
+		final String zarr3Path = basePath + ".zarr";
+		final N5WriterSupplier zarr3Supplier = () -> new N5Factory().openWriter( StorageFormat.ZARR3, zarr3Path );
+
+		final long[] dimensions = { 32, 32, 32 };
+		final int[] blockSize = { 8, 8, 8 };
+		final int[] downsamplingFactors = { 2, 2, 2 };
+		final long[] offset = { 1, 1, 1 };
+		final int[] chunksPerShard = { 2, 2, 2 };
+
+		final N5Writer n5 = zarr3Supplier.get();
+		final int[] data = new int[ ( int ) Intervals.numElements( dimensions ) ];
+		for ( int i = 0; i < data.length; ++i )
+			data[ i ] = i + 1;
+		N5Utils.save( ArrayImgs.ints( data, dimensions ), n5, datasetPath, blockSize, new GzipCompression() );
+
+		/* downsample the same data, both unsharded and sharded, to compare later */
+		N5OffsetDownsamplerSpark.downsampleWithOffset( sparkContext, zarr3Supplier, datasetPath, "downsampled-unsharded", downsamplingFactors, offset, blockSize, null );
+		N5OffsetDownsamplerSpark.downsampleWithOffset( sparkContext, zarr3Supplier, datasetPath, "downsampled-sharded", downsamplingFactors, offset, blockSize, chunksPerShard );
+
+		final int[] expectedShardSize = new int[ blockSize.length ];
+		for ( int d = 0; d < blockSize.length; ++d )
+			expectedShardSize[ d ] = chunksPerShard[ d ] * blockSize[ d ];
+
+		final DatasetAttributes shardedAttributes = n5.getDatasetAttributes( "downsampled-sharded" );
+		Assert.assertArrayEquals( blockSize, shardedAttributes.getChunkSize() );          // inner chunk
+		Assert.assertArrayEquals( expectedShardSize, shardedAttributes.getBlockSize() );  // shard = chunksPerShard * chunk
+		Assert.assertArrayEquals( n5.getDatasetAttributes( "downsampled-unsharded" ).getDimensions(), shardedAttributes.getDimensions() );
+
+		/* the sharded output should be identical to the unsharded output */
+		Assert.assertArrayEquals(
+				getArrayFromRandomAccessibleInterval( N5Utils.open( n5, "downsampled-unsharded" ) ),
+				getArrayFromRandomAccessibleInterval( N5Utils.open( n5, "downsampled-sharded" ) )
+			);
+	}
 
 	private void createDataset( final N5Writer n5, final long[] dimensions, final int[] blockSize ) throws IOException
 	{


### PR DESCRIPTION
Rebased off of #43 

- migrate to n5 4.0 and related n5 libraries
- add sharded zarr3 output support for downsample calls.
  - The other n5-spark conversion steps support for sharded zarr3 outputs is TBD, but likely benefit from a larger refactor